### PR TITLE
REVERT: lower Gradio version that has less UI bugs

### DIFF
--- a/chat_with_rag/requirements.txt
+++ b/chat_with_rag/requirements.txt
@@ -1,4 +1,4 @@
-gradio~=5.0
+gradio~=4.44.1
 chromadb~=0.5.5
 python-dotenv~=1.0.1
 bcrypt~=4.2.0

--- a/demos/basic_chat/requirements.txt
+++ b/demos/basic_chat/requirements.txt
@@ -1,4 +1,4 @@
 openai~=1.13.3
-gradio~=5.0
+gradio~=4.44.1
 tiktoken~=0.6.0
 python-dotenv~=1.0.1

--- a/demos/rag/requirements.txt
+++ b/demos/rag/requirements.txt
@@ -1,3 +1,3 @@
 chromadb~=0.4.24
 pymupdf~=1.24.10
-gradio~=5.0
+gradio~=4.44.1

--- a/demos/tool_calling/requirements.txt
+++ b/demos/tool_calling/requirements.txt
@@ -1,4 +1,4 @@
-gradio~=5.0
+gradio~=4.44.1
 python-dotenv~=1.0.1
 openai~=1.13.3
 markdownify~=0.13.1


### PR DESCRIPTION
We are reverting to 4.x because version 5.0 currently breaks our UI.

More info here: https://github.com/gradio-app/gradio/issues/9724

This should be fixed soon in a new 5.x release, 
when this is fixed we will move back to version 5.x