### PR TITLE
FEAT: RAG can now list its documents

### DIFF
--- a/demos/tool_calling/chat_with_tool_calling.py
+++ b/demos/tool_calling/chat_with_tool_calling.py
@@ -20,7 +20,7 @@ from demos.tool_calling.tools_fileio import (list_files,
                                              delete_file,
                                              delete_folder)
 # noinspection PyUnresolvedReferences
-from tools_rag import lookup_in_documentation
+from tools_rag import lookup_in_documentation, list_documents
 # noinspection PyUnresolvedReferences
 from tools_search import search_on_google
 # noinspection PyUnresolvedReferences
@@ -31,7 +31,7 @@ from tools_weather import (get_current_temperature, get_current_rainfall)
 load_dotenv()
 
 tool_list = tools_weather_descriptor
-tool_list.append(tools_rag_descriptor)
+tool_list.extend(tools_rag_descriptor)
 tool_list.append(tools_search_descriptor)
 tool_list.extend(tools_get_website_contents)
 tool_list.extend(tools_fileio_descriptor)

--- a/demos/tool_calling/tool_descriptors.py
+++ b/demos/tool_calling/tool_descriptors.py
@@ -1,7 +1,7 @@
 # JSON description of available methods
 
 # RAG
-tools_rag_descriptor = {
+tools_rag_descriptor = [{
     "type": "function",
     "function": {
         "name": "lookup_in_documentation",
@@ -21,7 +21,20 @@ tools_rag_descriptor = {
             "required": ["query"],
         },
     }
-}
+}, {
+    "type": "function",
+    "function": {
+        "name": "list_documents",
+        "description": "Get the titles of the documents in the database. "
+                       "Use this as a (very rough) guide to know the topics you can rely on the database for. ",
+
+        "parameters": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    }
+}]
 
 # "weather" demo
 tools_weather_descriptor = [{

--- a/demos/tool_calling/tools_fileio.py
+++ b/demos/tool_calling/tools_fileio.py
@@ -78,6 +78,7 @@ def create_folders(folder_path: str) -> bool:
     print(f'Writing to {folder_path} is not allowed.')
     return False
 
+
 def get_fs_properties(path: str):
     if not os.path.exists(path):
         return None
@@ -151,6 +152,7 @@ def delete_file(file_path: str):
 
     print(f'Removing {file_path} is not allowed.')
     return False
+
 
 def delete_folder(folder_path: str):
     if is_within_folder(folder_path, allowed_folder):

--- a/demos/tool_calling/tools_rag.py
+++ b/demos/tool_calling/tools_rag.py
@@ -13,6 +13,10 @@ cdb_path = os.getenv("CHROMA_LOCATION")
 cdb_store = ChromaDocumentStore(path=cdb_path)  # on disk
 
 
+def list_documents():
+    return cdb_store.list_documents()
+
+
 def lookup_in_documentation(query):
     print(f"Searching in company docs: '{query}'")
     results = cdb_store.query_store(query)


### PR DESCRIPTION
This pull request includes several updates to the `demos/tool_calling` module, primarily focusing on enhancing the functionality of the tools and improving code quality. The most important changes include adding a new function for listing documents, modifying tool descriptors, and improving the handling of tool lists.

### Enhancements to tool functionality:

* [`demos/tool_calling/tools_rag.py`](diffhunk://#diff-8900fbc36e232b2c2315df8304d4760353a5e7a479256576a9a2d9725e8f8a83R16-R19): Added a new function `list_documents` to retrieve the titles of documents in the database.
* [`demos/tool_calling/tool_descriptors.py`](diffhunk://#diff-3bff22a18d3e5fd323c13c4bc2a97b7204e23349acad5a67a00f0b5749076ad5L4-R4): Updated `tools_rag_descriptor` to include the new `list_documents` function, allowing it to be used as a tool. [[1]](diffhunk://#diff-3bff22a18d3e5fd323c13c4bc2a97b7204e23349acad5a67a00f0b5749076ad5L4-R4) [[2]](diffhunk://#diff-3bff22a18d3e5fd323c13c4bc2a97b7204e23349acad5a67a00f0b5749076ad5R24-R37)

### Improvements to tool list handling:

* [`demos/tool_calling/chat_with_tool_calling.py`](diffhunk://#diff-f1ffd7c5600b6be868dbf39936cc22eb629808bde0ff96c79d24278bb8ba9248L34-R34): Changed the method of adding `tools_rag_descriptor` to `tool_list` from `append` to `extend` to ensure all tools are included.

### Code quality improvements:

* [`demos/tool_calling/chat_with_tool_calling.py`](diffhunk://#diff-f1ffd7c5600b6be868dbf39936cc22eb629808bde0ff96c79d24278bb8ba9248L23-R23): Updated the import statement to include the new `list_documents` function.
* [`demos/tool_calling/tools_fileio.py`](diffhunk://#diff-43ac2da5d428cd413120ef0484e271bfc119f4c4ae91cbe93634b489baa4b538R81): Added blank lines for better readability in the `create_folders` and `delete_file` functions. [[1]](diffhunk://#diff-43ac2da5d428cd413120ef0484e271bfc119f4c4ae91cbe93634b489baa4b538R81) [[2]](diffhunk://#diff-43ac2da5d428cd413120ef0484e271bfc119f4c4ae91cbe93634b489baa4b538R156)