### PR TITLE
CHANGE: small change to prompt in model choice demo

### DIFF
--- a/demos/model_choice/chat_with_model_choice.py
+++ b/demos/model_choice/chat_with_model_choice.py
@@ -15,9 +15,10 @@ load_dotenv()
 
 system_instruction = {
     'role': 'system',
-    'content': 'Be concise. Be precise. Always think step by step. '
-               'I would like you to take a deep breath before responding. '
-               'You can answer using Markdown syntax if you want to. '
+    'content': 'You are a helpful assistant. Try to be concise and precise. '
+               'Take a deep breath before responding. '
+               'Always think step by step, but only keep a minimum draft for each thinking step, with 25 words at most. '
+               'Answer using Markdown syntax to structure your text. '
                'When using an external source, always include the reference. '
 }
 


### PR DESCRIPTION
This pull request updates the system instruction in the `chat_with_model_choice.py` demo to refine the assistant's behavior and improve response clarity.

Updates to system instruction:

* [`demos/model_choice/chat_with_model_choice.py`](diffhunk://#diff-4cd7ed308c127c7efc6a6eb5d34b0627272e76e11b858383401cbf858cfb1747L18-R21): Modified the `content` field in `system_instruction` to define the assistant as helpful, concise, and precise. Added a guideline to limit thinking steps to 25 words and emphasized using Markdown syntax for structured responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated system instructions to clarify assistant behavior, emphasizing step-by-step reasoning, concise drafts, and mandatory use of Markdown formatting in responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->