### PR TITLE
FIX: updated an outdated label

### DIFF
--- a/applications/chat_with_rag/launch_ui.py
+++ b/applications/chat_with_rag/launch_ui.py
@@ -107,7 +107,7 @@ def on_row_selected(select_data: gr.SelectData):
 
 rag_explainer = (
     'Upload additional information here if you want the language model to be able to perform lookup into it. '
-    'Do not upload data files such as spreadsheets or tables; stick to PDF only. '
+    'You can upload documents such as PDFs, Word documents, PowerPoint presentations, and Excel spreadsheets. '
     'Processing may take considerable time depending on the size of the documents. '
     'Do not interrupt the processing step.')
 

--- a/applications/faq_tool/launch_upload_ui.py
+++ b/applications/faq_tool/launch_upload_ui.py
@@ -47,7 +47,7 @@ def wrap_document_list():
 
 rag_explainer = (
     'Upload additional information here if you want the language model to be able to perform lookup into it. '
-    'Do not upload data files such as spreadsheets or tables; stick to PDF only. '
+    'You can upload documents such as PDFs, Word documents, PowerPoint presentations, and Excel spreadsheets. '
     'Processing may take considerable time depending on the size of the documents. '
     'Do not interrupt the processing step.')
 


### PR DESCRIPTION
This pull request updates the document upload instructions across two files to clarify the types of documents supported. The changes expand the list of acceptable file formats for upload and provide consistent messaging.

Updates to document upload instructions:

* [`applications/chat_with_rag/launch_ui.py`](diffhunk://#diff-444001152c6700a78c0bd05992e372ac24fb9b151fb0fb062fd784ceef460b19L110-R110): Updated the `rag_explainer` message in the `on_row_selected` function to allow uploads of PDFs, Word documents, PowerPoint presentations, and Excel spreadsheets, replacing the previous restriction to PDF files only.
* [`applications/faq_tool/launch_upload_ui.py`](diffhunk://#diff-611b3777739318dc9cbfb13ed37ecf0accd3bee22aaede9f00cd82f4d8905898L50-R50): Updated the `rag_explainer` message in the `wrap_document_list` function with the same expanded list of supported document formats for consistency.