### PR TITLE
CHANGE: demo now complies with dict format for messages

### DIFF
--- a/applications/chat_with_rag/blocks_view_history.py
+++ b/applications/chat_with_rag/blocks_view_history.py
@@ -56,10 +56,10 @@ def file_selected(chosen_file):
 
     chat_history = []
     for message in messages["data"]:
-        if message["role"] == "user" and message["content"][0]["type"] == "text":
-            chat_history.append((message["content"][0]["text"]["value"], None))
-        elif message["role"] == "assistant" and message["content"][0]["type"] == "text":
-            chat_history.append((None, message["content"][0]["text"]["value"]))
+        if message.get("role") == "user":
+            chat_history.append({"role": "user", "content": message["content"][0]["text"]["value"]})
+        elif message.get("role") == "assistant":
+            chat_history.append({"role": "assistant", "content": message["content"][0]["text"]["value"]})
 
     return chat_history
 

--- a/applications/chat_with_rag/launch_ui.py
+++ b/applications/chat_with_rag/launch_ui.py
@@ -28,12 +28,12 @@ from demos.components.fn_auth import auth_method
 
 def show_live():
     return {
-        cb_live_chat: gr.Chatbot(visible=True),
+        cb_live_chat: gr.Chatbot(visible=True, type='messages'),
         gr_live: gr.Group(visible=True),
         row_live: gr.Row(visible=True),
         btn_live: gr.Button(interactive=False),
 
-        cb_chat_history: gr.Chatbot(visible=False),
+        cb_chat_history: gr.Chatbot(visible=False, type='messages'),
         gr_history: gr.Group(visible=False),
         btn_history: gr.Button(interactive=True),
 
@@ -47,12 +47,12 @@ def show_live():
 
 def show_history():
     return {
-        cb_live_chat: gr.Chatbot(visible=False),
+        cb_live_chat: gr.Chatbot(visible=False, type='messages'),
         gr_live: gr.Group(visible=False),
         row_live: gr.Row(visible=False),
         btn_live: gr.Button(interactive=True),
 
-        cb_chat_history: gr.Chatbot(visible=True),
+        cb_chat_history: gr.Chatbot(visible=True, type='messages'),
         gr_history: gr.Group(visible=True),
         btn_history: gr.Button(interactive=False),
 
@@ -66,12 +66,12 @@ def show_history():
 
 def show_upload():
     return {
-        cb_live_chat: gr.Chatbot(visible=False),
+        cb_live_chat: gr.Chatbot(visible=False, type='messages'),
         gr_live: gr.Group(visible=False),
         row_live: gr.Row(visible=False),
         btn_live: gr.Button(interactive=True),
 
-        cb_chat_history: gr.Chatbot(visible=False),
+        cb_chat_history: gr.Chatbot(visible=False, type='messages'),
         gr_history: gr.Group(visible=False),
         btn_history: gr.Button(interactive=True),
 
@@ -91,7 +91,7 @@ def on_login(request: gr.Request):
 
 
 def show_chat():
-    return {cb_live_chat: gr.Chatbot(visible=True)}
+    return {cb_live_chat: gr.Chatbot(visible=True, type='messages')}
 
 
 def on_remove_rag(file_list, select_data):
@@ -155,7 +155,7 @@ with (gr.Blocks(fill_height=True, title='Pixie Lite', css=custom_css) as llm_cli
         gr.Markdown('# PiXie Lite')
 
     # live chat UI
-    cb_live_chat = gr.Chatbot(label='Chat', type='tuples', scale=1, visible=False, show_copy_button=True)
+    cb_live_chat = gr.Chatbot(label='Chat', type='messages', scale=1, visible=False, show_copy_button=True)
 
     with gr.Group(elem_classes='max_height') as gr_live:
         with gr.Row():
@@ -175,7 +175,7 @@ with (gr.Blocks(fill_height=True, title='Pixie Lite', css=custom_css) as llm_cli
         btn_clear_chat.click(clear_chat, [], [tb_user_prompt, cb_live_chat, st_thread])
 
     # log viewer UI
-    cb_chat_history = gr.Chatbot(label='History', type='tuples', scale=1, visible=False)
+    cb_chat_history = gr.Chatbot(label='History', type='messages', scale=1, visible=False)
 
     with gr.Group(visible=False) as gr_history:
         with gr.Row():


### PR DESCRIPTION
This pull request refactors the `applications/chat_with_rag` module to improve the handling of chat history and unify the data structure for chatbot messages. It also updates the UI components to use a consistent message type across different views.

### Refactoring chat history handling:

* [`applications/chat_with_rag/blocks_llm_chat_with_rag.py`](diffhunk://#diff-caefd17c5516ce80c80f3c2895c7ec7a65c8752e0cc272f665babb8b19678364L65-R66): Updated `append_user`, `append_ai`, and `estimate_costs` functions to use a dictionary-based structure (`{"role": ..., "content": ...}`) for chat history instead of tuples. This ensures better clarity and extensibility in handling user and assistant messages. [[1]](diffhunk://#diff-caefd17c5516ce80c80f3c2895c7ec7a65c8752e0cc272f665babb8b19678364L65-R66) [[2]](diffhunk://#diff-caefd17c5516ce80c80f3c2895c7ec7a65c8752e0cc272f665babb8b19678364L135-R140) [[3]](diffhunk://#diff-caefd17c5516ce80c80f3c2895c7ec7a65c8752e0cc272f665babb8b19678364L153-R157)
* [`applications/chat_with_rag/blocks_view_history.py`](diffhunk://#diff-d76aa7b3e14c6445ca647ee0d9e50a9aa0b0273848202c50974adf9567fa0ba1L59-R62): Modified the `file_selected` function to adopt the same dictionary-based structure for chat history when parsing messages from files.

### UI updates for consistency:

* [`applications/chat_with_rag/launch_ui.py`](diffhunk://#diff-444001152c6700a78c0bd05992e372ac24fb9b151fb0fb062fd784ceef460b19L31-R36): Changed all instances of `gr.Chatbot` components to use the `type='messages'` parameter instead of `type='tuples'`, ensuring consistency with the updated chat history structure. This affects live chat, chat history, and other views. [[1]](diffhunk://#diff-444001152c6700a78c0bd05992e372ac24fb9b151fb0fb062fd784ceef460b19L31-R36) [[2]](diffhunk://#diff-444001152c6700a78c0bd05992e372ac24fb9b151fb0fb062fd784ceef460b19L50-R55) [[3]](diffhunk://#diff-444001152c6700a78c0bd05992e372ac24fb9b151fb0fb062fd784ceef460b19L69-R74) [[4]](diffhunk://#diff-444001152c6700a78c0bd05992e372ac24fb9b151fb0fb062fd784ceef460b19L94-R94) [[5]](diffhunk://#diff-444001152c6700a78c0bd05992e372ac24fb9b151fb0fb062fd784ceef460b19L158-R158) [[6]](diffhunk://#diff-444001152c6700a78c0bd05992e372ac24fb9b151fb0fb062fd784ceef460b19L178-R178)