### PR TITLE
FEAT: now displays input / output tokens instead of (wrong) cost

### DIFF
--- a/applications/chat_with_rag/blocks_llm_chat_with_rag.py
+++ b/applications/chat_with_rag/blocks_llm_chat_with_rag.py
@@ -134,20 +134,22 @@ def append_ai(thread, message, chat_history, log_folder):
     )
 
     for msg_data in messages.data:
-        if msg_data.role == "assistant" and msg_data.content and len(msg_data.content) > 0 and msg_data.content[
-            0].type == "text":
+        if (msg_data.role == "assistant"
+                and msg_data.content
+                and len(msg_data.content) > 0
+                and msg_data.content[0].type == "text"):
             bot_message = msg_data.content[0].text.value
             chat_history.append({"role": msg_data.role, "content": bot_message})
 
     # cost estimate
-    (token_count, cost_in_cents) = estimate_costs(chat_history)
-    debug = f"Cost estimate for {token_count} tokens: {cost_in_cents:.3f} cents"
+    (token_count_prompts, token_count_responses) = estimate_token_count(chat_history)
+    debug = f"Token estimate:  {token_count_prompts} input tokens and {token_count_responses} output tokens."
 
     store_thread(thread, log_folder)
     return "", chat_history, debug
 
 
-def estimate_costs(chat_history):
+def estimate_token_count(chat_history):
     prompt_log = ""
     response_log = ""
     for msg in chat_history:
@@ -159,12 +161,5 @@ def estimate_costs(chat_history):
     tokeniser = tiktoken.encoding_for_model("gpt-4")
     token_count_prompts = len(tokeniser.encode(prompt_log))
     token_count_responses = len(tokeniser.encode(response_log))
-    input_1k = 0.00015
-    output_1k = 0.00060
-    # WARNING: this is an underestimation because we do not take the RAG / context into account
-    # TEMP WORKAROUND: we do this * 10
-    # TODO: fix this calculation
-    cost_prompts = round(token_count_prompts / 1000 * input_1k * 10, 4)
-    cost_responses = round(token_count_responses / 1000 * output_1k * 10, 4)
 
-    return (token_count_prompts + token_count_responses), (cost_prompts + cost_responses)
+    return token_count_prompts, token_count_responses


### PR DESCRIPTION
This pull request refactors the token estimation logic in the `applications/chat_with_rag/blocks_llm_chat_with_rag.py` file to improve clarity and remove outdated cost calculation code. The changes focus on simplifying the `estimate_token_count` function and updating related logic in `append_ai`.

### Refactoring for token estimation:

* [`applications/chat_with_rag/blocks_llm_chat_with_rag.py`](diffhunk://#diff-caefd17c5516ce80c80f3c2895c7ec7a65c8752e0cc272f665babb8b19678364L162-R165): Replaced the `estimate_costs` function with `estimate_token_count`, removing outdated cost calculation logic and simplifying the return values to only include token counts for prompts and responses.

### Updates to `append_ai` function:

* [`applications/chat_with_rag/blocks_llm_chat_with_rag.py`](diffhunk://#diff-caefd17c5516ce80c80f3c2895c7ec7a65c8752e0cc272f665babb8b19678364L137-R152): Updated the `append_ai` function to use the new `estimate_token_count` function, replacing the debug message to display token counts instead of cost estimates. Improved readability by reformatting a conditional statement.