### PR TITLE
FIX: second attempt at valid dependabot script

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,23 +37,6 @@ updates:
       - "stilkin-pxl"
 
   - package-ecosystem: pip
-    directory: "/applications/chat_with_rag_sm"
-    schedule:
-      interval: daily
-      time: "04:00"
-    groups:
-      python-packages:
-        patterns:
-          - "*"
-    pull-request-branch-name:
-      separator: "-"
-    labels:
-      - "dependencies"
-      - "python"
-    reviewers:
-      - "stilkin-pxl"
-
-  - package-ecosystem: pip
     directory: "/applications/chat_with_rag"
     schedule:
       interval: daily

--- a/.github/generate_dependabot_yaml.py
+++ b/.github/generate_dependabot_yaml.py
@@ -9,23 +9,6 @@ OUTPUT_FILE = "dependabot_new.yml"
 
 dependabot_config = """
 version: 2
-defaults: &defaults
-  package-ecosystem: pip
-  schedule:
-    interval: daily
-    time: "04:00"
-  groups:
-    python-packages:
-      patterns:
-        - "*"
-  pull-request-branch-name:
-    separator: "-"
-  labels:
-    - "dependencies"
-    - "python"
-  reviewers:
-    - "stilkin-pxl"
-
 updates:
 """
 
@@ -33,14 +16,27 @@ updates:
 for root, dirs, files in os.walk(REPO_ROOT):
     if "requirements.txt" in files:
         relative_path = os.path.relpath(root, REPO_ROOT)
-        print(relative_path)
         dependabot_config += f"""
-  - directory: "/{relative_path}"
-    <<: *defaults
+  - package-ecosystem: pip
+    directory: "/{relative_path}"
+    schedule:
+      interval: daily
+      time: "04:00"
+    groups:
+      python-packages:
+        patterns:
+          - "*"
+    pull-request-branch-name:
+      separator: "-"
+    labels:
+      - "dependencies"
+      - "python"
+    reviewers:
+      - "stilkin-pxl"
 """
 
 # Save the configuration
-with open(OUTPUT_FILE, "wt") as f:
+with open(OUTPUT_FILE, "w") as f:
     f.write(dependabot_config)
 
 print(f"Generated {OUTPUT_FILE}")


### PR DESCRIPTION
This pull request updates the way Dependabot configuration is generated for Python projects in the repository. The main change is the automation and simplification of the `.github/dependabot.yml` generation process, ensuring that all directories with a `requirements.txt` file are automatically included for dependency updates.

**Dependabot configuration automation:**

* Updated `.github/generate_dependabot_yaml.py` to programmatically find all directories containing `requirements.txt` and add them to the Dependabot configuration, removing the need for manually listing each directory. [[1]](diffhunk://#diff-f62b61568e4455191ed6c96442d609d72cdbf2294c2745f08072b6148032f653L12-R21) [[2]](diffhunk://#diff-f62b61568e4455191ed6c96442d609d72cdbf2294c2745f08072b6148032f653L28-R39)
