### PR TITLE
CHANGE: removed constant use from ORC file

### DIFF
--- a/applications/faq_tool/launch_faq_tool.py
+++ b/applications/faq_tool/launch_faq_tool.py
@@ -7,7 +7,7 @@ import gradio as gr
 from dotenv import load_dotenv
 
 sys.path.append('../../')
-from demos.components.open_router_client import OpenRouterClient, GPT_4O_MINI
+from demos.components.open_router_client import OpenRouterClient
 from demos.tool_calling.tool_descriptors import (tools_rag_descriptor)
 
 # noinspection PyUnresolvedReferences
@@ -21,7 +21,7 @@ custom_headers = {
 }
 
 tool_list = tools_rag_descriptor
-or_client = OpenRouterClient(model_name='openai/gpt-4.1',
+or_client = OpenRouterClient(model_name='anthropic/claude-haiku-4.5',
                              tools_list=tool_list,
                              api_key=os.getenv('OPENROUTER_API_KEY'),
                              temperature=0.25,

--- a/demos/components/open_router_client.py
+++ b/demos/components/open_router_client.py
@@ -11,7 +11,7 @@ class OpenRouterClient(OpenAI):
     def __init__(self,
                  api_key: str,
                  base_url: str = 'https://openrouter.ai/api/v1',
-                 model_name: str = 'openai/gpt-4o-mini',
+                 model_name: str = 'anthropic/claude-haiku-4.5',
                  tools_list: list = None,
                  temperature: float = 0,
                  custom_headers=None):
@@ -58,13 +58,3 @@ DEEPSEEK_V3 = 'deepseek/deepseek-chat'
 GPT_4O = 'openai/chatgpt-4o'
 GPT_4O_LATEST = 'openai/chatgpt-4o-latest'
 GPT_4O_MINI = 'openai/gpt-4o-mini-2024-07-18'
-
-# older constants
-O3_MINI_HIGH = 'openai/o3-mini-high'
-O3_MINI = 'openai/o3-mini'
-GEMINI_PRO_15 = 'google/gemini-pro-1.5'
-GPT_4O_1305 = 'openai/gpt-4o-2024-05-13'
-QWEN_25_PLUS = 'qwen/qwen-plus'
-LLAMA_405B_I = 'meta-llama/llama-3.1-405b-instruct'
-CLAUDE_35_SONNET_2006 = 'anthropic/claude-3.5-sonnet-20240620'
-GEMINI_2_FLASH_LITE = 'google/gemini-2.0-flash-lite-001'

--- a/demos/slack_bot/slack_or_with_tool_calling.py
+++ b/demos/slack_bot/slack_or_with_tool_calling.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 
-from demos.components.open_router_client import OpenRouterClient, GPT_4O_MINI
+from demos.components.open_router_client import OpenRouterClient
 from demos.tool_calling.tool_descriptors import (tools_rag_descriptor,
                                                  tools_search_descriptor,
                                                  tools_get_website_contents)


### PR DESCRIPTION
This pull request updates the default and used language model in the FAQ tool and Slack bot components to use Anthropic's Claude Haiku 4.5 instead of OpenAI's GPT-4o Mini. It also removes unused model constants from the `open_router_client` module, simplifying the codebase and imports.

**Model selection updates:**

* Changed the default model in `OpenRouterClient` from `'openai/gpt-4o-mini'` to `'anthropic/claude-haiku-4.5'` in `demos/components/open_router_client.py` and updated instantiations in `applications/faq_tool/launch_faq_tool.py`. [[1]](diffhunk://#diff-19d10475d247f7f3795a2e0b1fc5f48f13dce7a0bb9c8a0cbedf2369349c30f6L14-R14) [[2]](diffhunk://#diff-6b4c70fc3402373feebbbec1f6b2a46a8d2239186d997633ab8ccd96cdb9a8b7L24-R24)
* Updated imports in both `applications/faq_tool/launch_faq_tool.py` and `demos/slack_bot/slack_or_with_tool_calling.py` to remove unused `GPT_4O_MINI`. [[1]](diffhunk://#diff-6b4c70fc3402373feebbbec1f6b2a46a8d2239186d997633ab8ccd96cdb9a8b7L10-R10) [[2]](diffhunk://#diff-5127e6887fe1dcc3f9a5169e073324ec8ba158c53e10dda4b46cd2cd98f6a80fL9-R9)

**Codebase simplification:**

* Removed unused older model constants from `demos/components/open_router_client.py`, reducing clutter and potential confusion.