### PR TITLE
Development

### DIFF
--- a/applications/chat_with_rag/requirements.txt
+++ b/applications/chat_with_rag/requirements.txt
@@ -1,7 +1,7 @@
 gradio~=5.49.1
 openai~=2.7.1
-chromadb~=1.3.3
-python-dotenv~=1.2.1
+chromadb~=1.3.5
+python-dotenv~=1.2.2
 bcrypt~=4.3.0
 tiktoken~=0.12.0
-markitdown[pdf, docx, pptx, xlsx, xls]~=0.1.3
+markitdown[pdf, docx, pptx, xlsx, xls]~=0.1.4

--- a/applications/faq_tool/launch_faq_tool.py
+++ b/applications/faq_tool/launch_faq_tool.py
@@ -98,11 +98,11 @@ def complete_with_llm(chat_history, message_list, log_file_name):
                         tool_calls.insert(tool_call_chunk.index, tool_call_chunk)
                     else:
                         if tool_call_chunk.function is not None:
-                            if tool_calls[tool_call_chunk.index].function is None:
+                            existing = tool_calls[tool_call_chunk.index].function
+                            if existing is None:
                                 tool_calls[tool_call_chunk.index].function = tool_call_chunk.function
                             else:
-                                tool_calls[
-                                    tool_call_chunk.index].function.arguments += tool_call_chunk.function.arguments
+                                existing.arguments = (existing.arguments or '') + (tool_call_chunk.function.arguments or '')
 
     response_stream.close()
 

--- a/applications/faq_tool/requirements.txt
+++ b/applications/faq_tool/requirements.txt
@@ -1,6 +1,6 @@
-python-dotenv~=1.2.1
+python-dotenv~=1.2.2
 gradio~=5.49.1
 openai~=2.7.1
 chromadb~=1.3.3
-tqdm~=4.67.1
-markitdown[pdf, docx, pptx, xlsx, xls]~=0.1.3
+tqdm~=4.67.2
+markitdown[pdf, docx, pptx, xlsx, xls]~=0.1.4

--- a/components/open_router/or_model_filtering.py
+++ b/components/open_router/or_model_filtering.py
@@ -21,7 +21,7 @@ def get_models(tools_only=False,
 
     response = requests.get(models_url)
     model_list = json.loads(response.text)
-    print(f'{len(model_list['data'])} models are available.')
+    print(f'{len(model_list["data"])} models are available.')
 
     filtered_data = model_list['data']
 

--- a/components/open_router/or_model_filtering.py
+++ b/components/open_router/or_model_filtering.py
@@ -13,7 +13,8 @@ def get_models(tools_only=False,
                max_completion_price=0,  # good value: 20
                max_prompt_price=0,  # good value: 10
                skip_free=True,
-               skip_experimental=True):
+               skip_experimental=True,
+               exacto_only=False):
     models_url = 'https://openrouter.ai/api/v1/models'
     if tools_only:
         models_url += '?supported_parameters=tools'
@@ -45,10 +46,14 @@ def get_models(tools_only=False,
         filtered_data = [m for m in filtered_data if
                          float(m['pricing']['prompt']) > 0]  # remove free ones because they are rate limited
 
+    # modality
     if image_only:
         filtered_data = [m for m in filtered_data if
                          'image' in m.get('architecture', {}).get('input_modalities', [])
                          and 'text' in m.get('architecture', {}).get('input_modalities', [])]  # image input support
+
+    if exacto_only:
+        filtered_data = [m for m in filtered_data if ':exacto' in m['id']]  # exacto only
 
     print(f'{len(filtered_data)} models left after filtering ...\n')
 
@@ -103,5 +108,6 @@ if __name__ == "__main__":
                             max_completion_price=100,
                             max_prompt_price=20,
                             skip_free=True,
-                            skip_experimental=True)
+                            skip_experimental=True,
+                            exacto_only=True)
         pp.pprint(models)

--- a/components/text_utils/md_conversion.py
+++ b/components/text_utils/md_conversion.py
@@ -34,3 +34,17 @@ def image_description(img_filename: str) -> str:
                     llm_prompt='Describe the following image in detail, in Dutch, using Markdown format')
     result = md.convert(img_filename)
     return result.text_content
+
+
+if __name__ == '__main__':
+    # convert a document (passed as parameter) to markdown and store in a .md file
+    if len(sys.argv) < 2:
+        print('Usage: python md_conversion.py <document_filename>')
+        sys.exit(1)
+
+    doc_filename = sys.argv[1]
+    md_text = document_to_markdown(doc_filename)
+    md_filename = os.path.splitext(doc_filename)[0] + '.md'
+    with open(md_filename, 'w', encoding='utf-8') as f:
+        f.write(md_text)
+    print(f'Converted {doc_filename} to {md_filename}')

--- a/demos/basic_chat/requirements.txt
+++ b/demos/basic_chat/requirements.txt
@@ -1,4 +1,4 @@
 openai~=2.7.1
 gradio~=5.49.1
 tiktoken~=0.12.0
-python-dotenv~=1.2.1
+python-dotenv~=1.2.2

--- a/demos/image_analysis/requirements.txt
+++ b/demos/image_analysis/requirements.txt
@@ -1,7 +1,7 @@
 streamlit~=1.51.0
 openai~=2.7.1
 requests~=2.32.5
-python-dotenv~=1.2.1
+python-dotenv~=1.2.2
 pandas~=2.3.3
 thefuzz~=0.22.1
 python-Levenshtein~=0.27.3

--- a/demos/mcp_server_file_io/requirements.txt
+++ b/demos/mcp_server_file_io/requirements.txt
@@ -1,2 +1,2 @@
 mcp[cli]~=1.20.0
-python-dotenv~=1.2.1
+python-dotenv~=1.2.2

--- a/demos/model_choice/requirements.txt
+++ b/demos/model_choice/requirements.txt
@@ -1,6 +1,6 @@
 gradio~=5.49.1
 openai~=2.7.1
-python-dotenv~=1.2.1
+python-dotenv~=1.2.2
 requests~=2.32.5
 pandas~=2.3.3
 thefuzz~=0.22.1

--- a/demos/rag/requirements.txt
+++ b/demos/rag/requirements.txt
@@ -1,4 +1,4 @@
 gradio~=5.49.1
 chromadb~=1.3.3
-markitdown[pdf, docx, pptx, xlsx, xls]~=0.1.3
-tqdm~=4.67.1
+markitdown[pdf, docx, pptx, xlsx, xls]~=0.1.4
+tqdm~=4.67.2

--- a/demos/slack_bot/requirements.txt
+++ b/demos/slack_bot/requirements.txt
@@ -1,6 +1,6 @@
-python-dotenv~=1.2.1
+python-dotenv~=1.2.2
 openai~=2.7.1
 slack_bolt~=1.26.0
-markdownify~=1.2.0
+markdownify~=1.2.2
 selenium~=4.38.0
 webdriver-manager~=4.0.2

--- a/demos/tool_calling/chat_with_tool_calling.py
+++ b/demos/tool_calling/chat_with_tool_calling.py
@@ -90,12 +90,11 @@ def complete_with_llm(chat_history, message_list):
                         tool_calls.insert(tool_call_chunk.index, tool_call_chunk)
                     else:
                         if tool_call_chunk.function is not None:
-                            if tool_calls[tool_call_chunk.index].function is None:
+                            existing = tool_calls[tool_call_chunk.index].function
+                            if existing is None:
                                 tool_calls[tool_call_chunk.index].function = tool_call_chunk.function
                             else:
-                                # print(f"args: {tool_call_chunk.function.arguments}")
-                                tool_calls[
-                                    tool_call_chunk.index].function.arguments += tool_call_chunk.function.arguments
+                                existing.arguments = (existing.arguments or '') + (tool_call_chunk.function.arguments or '')
 
     response_stream.close()
 

--- a/demos/tool_calling/chat_with_tool_calling.py
+++ b/demos/tool_calling/chat_with_tool_calling.py
@@ -6,10 +6,10 @@ from dotenv import load_dotenv
 
 from components.open_router.open_router_client import OpenRouterClient
 from demos.tool_calling.descriptors_fileio import tools_fileio_descriptor
-from demos.tool_calling.tool_descriptors import (tools_weather_descriptor,
-                                                 tools_rag_descriptor,
-                                                 tools_search_descriptor,
-                                                 tools_get_website_contents)
+from demos.tool_calling.tool_descriptors import (tools_search_descriptor,
+                                                 tools_get_website_contents,
+                                                 tools_weather_descriptor,
+                                                 tools_rag_descriptor)
 # noinspection PyUnresolvedReferences
 from demos.tool_calling.tools_fileio import (list_files,
                                              get_fs_properties,
@@ -39,7 +39,7 @@ tool_list.extend(tools_fileio_descriptor)
 tool_list.append(tools_search_descriptor)  # requires GOOGLE_API_KEY
 tool_list.extend(tools_get_website_contents)
 
-or_client = OpenRouterClient(model_name='z-ai/glm-4.6',
+or_client = OpenRouterClient(model_name='openai/gpt-oss-120b:exacto',
                              tools_list=tool_list,
                              api_key=os.getenv('OPENROUTER_API_KEY'))
 
@@ -47,7 +47,7 @@ system_instruction = {
     'role': 'system',
     'content': 'You are a helpful assistant. '
                'Be concise, but include all relevant details. '
-               'Always think step by step. ' 
+               'Always think step by step. '
                'If unsure, state your assumptions. '
                'You can answer using Markdown syntax. '
                'You have a lot of tools at your disposal, think about when to use them. '
@@ -93,6 +93,7 @@ def complete_with_llm(chat_history, message_list):
                             if tool_calls[tool_call_chunk.index].function is None:
                                 tool_calls[tool_call_chunk.index].function = tool_call_chunk.function
                             else:
+                                # print(f"args: {tool_call_chunk.function.arguments}")
                                 tool_calls[
                                     tool_call_chunk.index].function.arguments += tool_call_chunk.function.arguments
 

--- a/demos/tool_calling/requirements.txt
+++ b/demos/tool_calling/requirements.txt
@@ -1,8 +1,8 @@
 gradio~=5.49.1
-python-dotenv~=1.2.1
+python-dotenv~=1.2.2
 openai~=2.7.1
-chromadb~=1.3.3
-markdownify~=1.2.0
+chromadb~=1.3.5
+markdownify~=1.2.2
 selenium~=4.38.0
 webdriver-manager~=4.0.2
 requests~=2.32.5

--- a/demos/voice_notes/requirements.txt
+++ b/demos/voice_notes/requirements.txt
@@ -1,7 +1,7 @@
 gradio~=5.49.1
 openai~=2.7.1
-python-dotenv~=1.2.1
-scipy~=1.16.1
+python-dotenv~=1.2.2
+scipy~=1.16.3
 transformers~=4.56.0
 accelerate~=1.4.0
 torch>=2.8.0


### PR DESCRIPTION
This pull request introduces improvements to model filtering logic, adds a command-line interface for Markdown conversion, and updates the demo to use a specific model and improve tool call handling. The most important changes are grouped below:

**Model Filtering Enhancements:**

* Added an `exacto_only` parameter to the `get_models` function in `or_model_filtering.py`, allowing filtering for models with `:exacto` in their ID. The filtering logic and a sample call in `no_duplicates` were updated accordingly. [[1]](diffhunk://#diff-9f089cd6752457a2c582d651fad9af41c97a64f5acac1d056cc68081b5ea2ae9L16-R17) [[2]](diffhunk://#diff-9f089cd6752457a2c582d651fad9af41c97a64f5acac1d056cc68081b5ea2ae9R49-R57) [[3]](diffhunk://#diff-9f089cd6752457a2c582d651fad9af41c97a64f5acac1d056cc68081b5ea2ae9L106-R112)

**Markdown Conversion Utility:**

* Added a command-line interface to `md_conversion.py` that allows converting a document to Markdown via a script, writing the result to a `.md` file.

**Demo Improvements and Tool Call Handling:**

* Updated the demo in `chat_with_tool_calling.py` to use the `openai/gpt-oss-120b:exacto` model by default, reordered tool imports for clarity, and improved tool call argument handling to concatenate arguments if a function is already present. [[1]](diffhunk://#diff-f1ffd7c5600b6be868dbf39936cc22eb629808bde0ff96c79d24278bb8ba9248L9-R12) [[2]](diffhunk://#diff-f1ffd7c5600b6be868dbf39936cc22eb629808bde0ff96c79d24278bb8ba9248L42-R42) [[3]](diffhunk://#diff-f1ffd7c5600b6be868dbf39936cc22eb629808bde0ff96c79d24278bb8ba9248R96)