### PR TITLE
Development

### DIFF
--- a/applications/chat_with_rag/requirements.txt
+++ b/applications/chat_with_rag/requirements.txt
@@ -1,7 +1,7 @@
-gradio~=6.17.3
-openai~=2.7.1
-chromadb~=1.3.5
+gradio~=6.19.0
+openai~=2.53.0
+chromadb~=1.5.9
 python-dotenv~=1.2.2
 bcrypt~=4.3.0
-tiktoken~=0.12.0
-markitdown[pdf, docx, pptx, xlsx, xls]~=0.1.4
+tiktoken~=0.13.0
+markitdown[pdf, docx, pptx, xlsx, xls]~=0.1.6

--- a/applications/faq_tool/requirements.txt
+++ b/applications/faq_tool/requirements.txt
@@ -1,6 +1,6 @@
 python-dotenv~=1.2.2
-gradio~=6.17.3
-openai~=2.7.1
-chromadb~=1.3.5
-tqdm~=4.67.2
-markitdown[pdf, docx, pptx, xlsx, xls]~=0.1.4
+gradio~=6.19.0
+openai~=2.53.0
+chromadb~=1.5.9
+tqdm~=4.68.2
+markitdown[pdf, docx, pptx, xlsx, xls]~=0.1.6

--- a/components/open_router/or_model_filtering.py
+++ b/components/open_router/or_model_filtering.py
@@ -59,8 +59,8 @@ def get_models(tools_only=False,
 
     md_data = []
     for model in filtered_data:
-        ppm_p = float(model['pricing']['prompt']) * PRICE_FACTOR
-        ppm_c = float(model['pricing']['completion']) * PRICE_FACTOR
+        ppm_p = round(float(model['pricing']['prompt']) * PRICE_FACTOR, 2)
+        ppm_c = round(float(model['pricing']['completion']) * PRICE_FACTOR, 2)
         md_data.append([model['id'],  # full_model_name
                         ppm_p,  # prompt_price
                         ppm_c,  # completion_price
@@ -90,6 +90,7 @@ def get_models(tools_only=False,
     pd.set_option('display.precision', 3)
 
     # saving
+    df_models = df_models.round(2)  # no long floating-point tails in any numeric column
     df_models.to_csv('or_models.csv')
 
     return df_models

--- a/components/open_router/or_model_filtering.py
+++ b/components/open_router/or_model_filtering.py
@@ -59,8 +59,8 @@ def get_models(tools_only=False,
 
     md_data = []
     for model in filtered_data:
-        ppm_p = round(float(model['pricing']['prompt']) * PRICE_FACTOR, 2)
-        ppm_c = round(float(model['pricing']['completion']) * PRICE_FACTOR, 2)
+        ppm_p = round(float(model['pricing']['prompt']) * PRICE_FACTOR, 3)
+        ppm_c = round(float(model['pricing']['completion']) * PRICE_FACTOR, 3)
         md_data.append([model['id'],  # full_model_name
                         ppm_p,  # prompt_price
                         ppm_c,  # completion_price
@@ -90,7 +90,7 @@ def get_models(tools_only=False,
     pd.set_option('display.precision', 3)
 
     # saving
-    df_models = df_models.round(2)  # no long floating-point tails in any numeric column
+    df_models = df_models.round(3)  # no long floating-point tails in any numeric column
     df_models.to_csv('or_models.csv')
 
     return df_models

--- a/demos/basic_chat/requirements.txt
+++ b/demos/basic_chat/requirements.txt
@@ -1,4 +1,4 @@
-openai~=2.7.1
-gradio~=6.17.3
-tiktoken~=0.12.0
+openai~=2.53.0
+gradio~=6.19.0
+tiktoken~=0.13.0
 python-dotenv~=1.2.2

--- a/demos/image_analysis/requirements.txt
+++ b/demos/image_analysis/requirements.txt
@@ -1,7 +1,7 @@
-streamlit~=1.54.0
-openai~=2.7.1
-requests~=2.33.0
+streamlit~=1.61.1
+openai~=2.53.0
+requests~=2.34.2
 python-dotenv~=1.2.2
 pandas~=2.3.3
 thefuzz~=0.22.1
-python-Levenshtein~=0.27.3
+python-Levenshtein~=0.27.4

--- a/demos/mcp_server_file_io/requirements.txt
+++ b/demos/mcp_server_file_io/requirements.txt
@@ -1,2 +1,2 @@
-mcp[cli]~=1.23.0
+mcp[cli]~=1.27.2
 python-dotenv~=1.2.2

--- a/demos/model_choice/README.md
+++ b/demos/model_choice/README.md
@@ -3,9 +3,15 @@
 ## What's in this folder?
 This folder contains a basic chatbot example where you can choose **which LLM you interact with**.
 
-- `chat_with_model_choice.py`: A basic chat app using OpenRouter.
+- `chat_with_model_choice.py`: A basic chat app using OpenRouter. The "_Available models_" list blends OpenRouter's pricing with an LM Arena quality score (see below) to show an estimated "LM Arena Score" and "Value Estimate" (cost, scaled by quality) per model.
 
-- `or_pricing.py`: A utility script that queries the OpenRouter API for information on available models and filters them based on certain criteria (e.g., context length, pricing). You can modify this script to include or exclude specific types of models. The results are also saved to `or_pricing.csv`.
+- `lmarena_download.py`: Downloads an LM Arena leaderboard snapshot (`overall` category) from the official [lmarena-ai/leaderboard-dataset](https://huggingface.co/datasets/lmarena-ai/leaderboard-dataset) on Hugging Face, and saves it as `lmarena_<subset>_<date>.csv`. Run it whenever you want to refresh the scores:
+  ```bash
+  python3 lmarena_download.py --subset text_style_control   # default
+  python3 lmarena_download.py --subset webdev
+  python3 lmarena_download.py --subset agent
+  ```
+  `chat_with_model_choice.py` picks up whichever CSV matches its `LMARENA_SUBSET` constant (loads the most recent dated file for that subset). Only one subset is used at a time — they're on different scales and aren't blended.
 
 ## Configuration
 
@@ -13,10 +19,12 @@ To install the necessary libraries, use `pip install -r requirements.txt`
 
 Please create an `.env` file with the same structure as the provided `.env.example` file, and enter your personal **API key** therein.
 
+Before first use (or whenever you want fresher scores), run `lmarena_download.py` to (re)generate the CSV for the subset configured in `chat_with_model_choice.py` (`LMARENA_SUBSET`, default `text_style_control`). Models OpenRouter doesn't have pricing for are skipped automatically (they never enter the OpenRouter-driven model list); OpenRouter models with no matching LM Arena score just show "N/A" for score/value.
+
 ## Use
 
 1.  Run the `chat_with_model_choice.py` script from the terminal (or your IDE). This will start a Gradio interface.
-2.  To switch to another LLM provider, click any of the rows in the "_Available models_" list. You can sort the list by name, price, or context length.
+2.  To switch to another LLM provider, click any of the rows in the "_Available models_" list. You can sort the list by name, price, context length, LM Arena score, or value estimate.
 
 _For more info regarding how Gradio works, please refer to the general README in this repository._
 

--- a/demos/model_choice/README.md
+++ b/demos/model_choice/README.md
@@ -27,7 +27,7 @@ To install the necessary libraries, use `pip install -r requirements.txt`
 
 Please create an `.env` file with the same structure as the provided `.env.example` file, and enter your personal **API key** therein.
 
-Before first use (or whenever you want fresher scores), run `lmarena_download.py` to (re)generate the CSV for the subset configured in `chat_with_model_choice.py` (`LMARENA_SUBSET`, default `text_style_control`). Models OpenRouter doesn't have pricing for are skipped automatically (they never enter the OpenRouter-driven model list); OpenRouter models with no matching LM Arena score just show "N/A" for score/cost.
+Before first use (or whenever you want fresher scores), run `lmarena_download.py` to (re)generate the CSV for the subset configured in `chat_with_model_choice.py` (`LMARENA_SUBSET`, default `text_style_control`). Models OpenRouter doesn't have pricing for are skipped automatically (they never enter the OpenRouter-driven model list); OpenRouter models with no matching LM Arena score still get a raw "Cost Estimate" (computed straight from OpenRouter pricing), but show "N/A" for LM Arena score and Scaled Cost Estimate.
 
 ## Use
 

--- a/demos/model_choice/README.md
+++ b/demos/model_choice/README.md
@@ -3,7 +3,7 @@
 ## What's in this folder?
 This folder contains a basic chatbot example where you can choose **which LLM you interact with**.
 
-- `chat_with_model_choice.py`: A basic chat app using OpenRouter. The "_Available models_" list blends OpenRouter's pricing with an LM Arena quality score (see below) to show an estimated "LM Arena Score" and "Value Estimate" (cost, scaled by quality) per model.
+- `chat_with_model_choice.py`: A basic chat app using OpenRouter. The "_Available models_" list blends OpenRouter's pricing with an LM Arena quality score (see below) to show an "LM Arena Score", a raw "Cost Estimate" (80% prompt price + 20% completion price), and a "Scaled Cost Estimate" (that cost, scaled down for higher-quality models and up for lower-quality ones) per model.
 
 - `lmarena_download.py`: Downloads an LM Arena leaderboard snapshot (`overall` category) from the official [lmarena-ai/leaderboard-dataset](https://huggingface.co/datasets/lmarena-ai/leaderboard-dataset) on Hugging Face, and saves it as `lmarena_<subset>_<date>.csv`. Run it whenever you want to refresh the scores:
   ```bash
@@ -13,18 +13,26 @@ This folder contains a basic chatbot example where you can choose **which LLM yo
   ```
   `chat_with_model_choice.py` picks up whichever CSV matches its `LMARENA_SUBSET` constant (loads the most recent dated file for that subset). Only one subset is used at a time — they're on different scales and aren't blended.
 
+- `lmarena_scoring.py`: Shared logic (not a script you run directly) for matching OpenRouter model ids to LM Arena entries and computing the cost columns above. Used by both `chat_with_model_choice.py` and `build_model_report.py`.
+
+- `build_model_report.py`: Fetches fresh OpenRouter pricing and an LM Arena snapshot, and writes a single combined CSV report (`or_lmarena_report.csv` by default) with pricing + LM Arena score + cost estimate columns — useful for browsing/filtering the full picture in a spreadsheet rather than the in-app dropdown (which caps prices and context length for a more manageable list). Also (re)generates `or_models.csv` and `lmarena_<subset>_<date>.csv` as a side effect.
+  ```bash
+  python3 build_model_report.py                        # text_style_control, -> or_lmarena_report.csv
+  python3 build_model_report.py --subset webdev --out or_lmarena_webdev.csv
+  ```
+
 ## Configuration
 
 To install the necessary libraries, use `pip install -r requirements.txt`
 
 Please create an `.env` file with the same structure as the provided `.env.example` file, and enter your personal **API key** therein.
 
-Before first use (or whenever you want fresher scores), run `lmarena_download.py` to (re)generate the CSV for the subset configured in `chat_with_model_choice.py` (`LMARENA_SUBSET`, default `text_style_control`). Models OpenRouter doesn't have pricing for are skipped automatically (they never enter the OpenRouter-driven model list); OpenRouter models with no matching LM Arena score just show "N/A" for score/value.
+Before first use (or whenever you want fresher scores), run `lmarena_download.py` to (re)generate the CSV for the subset configured in `chat_with_model_choice.py` (`LMARENA_SUBSET`, default `text_style_control`). Models OpenRouter doesn't have pricing for are skipped automatically (they never enter the OpenRouter-driven model list); OpenRouter models with no matching LM Arena score just show "N/A" for score/cost.
 
 ## Use
 
 1.  Run the `chat_with_model_choice.py` script from the terminal (or your IDE). This will start a Gradio interface.
-2.  To switch to another LLM provider, click any of the rows in the "_Available models_" list. You can sort the list by name, price, context length, LM Arena score, or value estimate.
+2.  To switch to another LLM provider, click any of the rows in the "_Available models_" list. You can sort the list by name, price, context length, LM Arena score, cost estimate, or scaled cost estimate.
 
 _For more info regarding how Gradio works, please refer to the general README in this repository._
 

--- a/demos/model_choice/build_model_report.py
+++ b/demos/model_choice/build_model_report.py
@@ -20,7 +20,7 @@ if __name__ == '__main__':
     print('Fetching OpenRouter pricing...')
     data_models = get_models(tools_only=False,
                              image_only=False,
-                             min_context=16000,
+                             min_context=0,
                              max_completion_price=0,
                              max_prompt_price=0,
                              skip_free=True,

--- a/demos/model_choice/build_model_report.py
+++ b/demos/model_choice/build_model_report.py
@@ -1,0 +1,38 @@
+import argparse
+import sys
+
+sys.path.append('../../')
+
+from components.open_router.or_model_filtering import get_models
+from lmarena_download import download_leaderboard, save_leaderboard_csv, SUBSET_SCORE_COLUMNS
+from lmarena_scoring import LMARENA_SUBSET, normalize_lmarena_df, enrich_with_lmarena
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Fetches fresh OpenRouter pricing (-> or_models.csv) and an LM '
+                                                  'Arena leaderboard snapshot (-> lmarena_<subset>_<date>.csv), '
+                                                  'then combines them into one CSV report with a quality score '
+                                                  'and cost-estimate columns alongside OpenRouter pricing.')
+    parser.add_argument('--subset', default=LMARENA_SUBSET, choices=sorted(SUBSET_SCORE_COLUMNS.keys()),
+                        help='Which LM Arena leaderboard to blend in.')
+    parser.add_argument('--out', default='or_lmarena_report.csv', help='Filename for the combined report.')
+    args = parser.parse_args()
+
+    print('Fetching OpenRouter pricing...')
+    data_models = get_models(tools_only=False,
+                             image_only=False,
+                             min_context=16000,
+                             max_completion_price=0,
+                             max_prompt_price=0,
+                             skip_free=True,
+                             skip_experimental=False)
+
+    print(f'Fetching LM Arena {args.subset!r} leaderboard...')
+    df_leaderboard = download_leaderboard(args.subset)
+    lmarena_path = save_leaderboard_csv(df_leaderboard, args.subset)
+    print(f'Saved LM Arena snapshot to {lmarena_path}')
+
+    data_models = enrich_with_lmarena(data_models, normalize_lmarena_df(df_leaderboard))
+    data_models.to_csv(args.out, index=False)
+
+    matched = data_models['lm_arena_score'].notna().sum()
+    print(f'Matched {matched}/{len(data_models)} models. Saved combined report to {args.out}')

--- a/demos/model_choice/chat_with_model_choice.py
+++ b/demos/model_choice/chat_with_model_choice.py
@@ -49,7 +49,7 @@ def on_load_ui():
     price_columns = data_models.filter(like='price').columns
     format_dict = {col: "{:.3f}".format for col in price_columns}
     format_dict.update({col: "{:.0f}".format for col in ['max_completion_tokens']})
-    format_dict.update({'lm_arena_score': "{:.0f}".format, 'cost_estimate': "{:.3f}".format,
+    format_dict.update({'lm_arena_score': "{:.2f}".format, 'cost_estimate': "{:.3f}".format,
                         'scaled_cost_estimate': "{:.3f}".format})
 
     style_models = (data_models.style

--- a/demos/model_choice/chat_with_model_choice.py
+++ b/demos/model_choice/chat_with_model_choice.py
@@ -1,14 +1,13 @@
 import copy
-import glob
 import os
 import random
-import re
 import sys
 
 import gradio as gr
 import pandas as pd
 from dotenv import load_dotenv
-from thefuzz import fuzz
+
+from lmarena_scoring import LMARENA_SUBSET, load_lmarena_scores, enrich_with_lmarena
 
 sys.path.append('../../')
 
@@ -32,124 +31,6 @@ different_colors = ['#e6194b', '#3cb44b', '#ffe119', '#4363d8', '#f58231', '#911
                     '#fabebe', '#008080', '#e6beff', '#9a6324', '#fffac8', '#aaffc3', '#808000', '#ffd8b1', '#808080']
 providers = {}
 
-# --- LM Arena "bang for the buck" configuration --------------------------------------------
-# Which lmarena_download.py --subset CSV to blend in (run that script to (re)generate it).
-# One arena at a time by design; swap this to switch, rather than blending several incompatible scales.
-LMARENA_SUBSET = 'text_style_control'
-LMARENA_FUZZY_THRESHOLD = 75
-
-# Reference models that calibrate the value-estimate curve (see compute_value_cost below).
-# 'good' tier -> cost is left unadjusted (multiplier 1.0) at this quality level.
-# 'very_good' tier -> the point where the effective cost is halved.
-LMARENA_ANCHOR_GOOD = ['anthropic/claude-sonnet-4-5', 'anthropic/claude-sonnet-4-6']
-LMARENA_ANCHOR_VERY_GOOD = ['anthropic/claude-opus-4-6', 'anthropic/claude-opus-4-7']
-
-# OpenRouter provider slug -> LM Arena organization, for the handful of providers whose
-# product-brand slug doesn't share a substring with LM Arena's corporate-entity name
-# (e.g. OpenRouter's "qwen" vs LM Arena's "Alibaba"). Everything else is resolved by
-# normalizing both names and checking for substring containment (handles cases like
-# "z-ai"/"Z.ai", "mistralai"/"Mistral", "meta-llama"/"Meta", "moonshotai"/"Moonshot").
-LMARENA_ORG_ALIASES = {
-    'qwen': 'alibaba',
-}
-
-
-def normalize_org(name):
-    return re.sub(r'[^a-z0-9]', '', str(name).lower())
-
-
-def canonicalize_version_numbers(name):
-    """Joins short major/minor-style version numbers (e.g. '3.5', '4-6') into one indivisible
-    token ('3p5', '4p6'), on both sides of the comparison. Without this, thefuzz's tokenizer
-    splits '5.5' into two lone '5' tokens, which can make an unrelated model (e.g. gpt-5.5) look
-    like a perfect token-subset match for a short query (e.g. gpt-3.5) purely by digit coincidence.
-    Longer digit runs (date stamps like '20250929') are left alone -- they're a different token."""
-    return re.sub(r'\b(\d{1,2})[.\-](\d{1,2})\b', r'\1p\2', name)
-
-
-def orgs_match(provider_norm, organization):
-    org_norm = normalize_org(organization)
-    if LMARENA_ORG_ALIASES.get(provider_norm) == org_norm:
-        return True
-    return provider_norm in org_norm or org_norm in provider_norm
-
-
-def load_lmarena_scores(subset):
-    """Loads the most recently downloaded lmarena_<subset>_*.csv into an organization/model_name/score
-    DataFrame, ready for best_fuzzy_score() to filter by organization and match by model name."""
-    pattern = os.path.join(os.path.dirname(os.path.abspath(__file__)), f'lmarena_{subset}_*.csv')
-    matches = sorted(glob.glob(pattern))
-    if not matches:
-        print(f"Warning: no LM Arena CSV found for subset '{subset}'. "
-             f"Run `python3 lmarena_download.py --subset {subset}` first.")
-        return pd.DataFrame(columns=['organization', 'model_name', 'score'])
-
-    df_scores = pd.read_csv(matches[-1], sep=';')
-    df_scores = df_scores.dropna(subset=['model_name'])
-    df_scores['organization'] = df_scores['organization'].fillna('')
-    df_scores['model_name'] = df_scores['model_name'].str.lower().apply(canonicalize_version_numbers)
-    return df_scores[['organization', 'model_name', 'score']]
-
-
-def best_fuzzy_score(full_model_name, score_df, threshold=LMARENA_FUZZY_THRESHOLD):
-    """Finds the best-matching LM Arena score for an OpenRouter model id, bridging OpenRouter's
-    `provider/slug` ids and LM Arena's own model naming (which adds date stamps, effort suffixes
-    like '-high'/'-thinking-32k', etc.).
-
-    Matching happens in two stages: first narrow the candidate pool to the same organization
-    (see orgs_match above) to rule out cross-provider false matches, then match by model name
-    only -- exact, then prefix (so an exact-version match always wins over a shorter but wrong
-    adjacent version number, e.g. '4-6' vs '4-7'), then fuzzy token_set_ratio as a last resort.
-    token_set_ratio is used rather than token_sort_ratio/ratio because it scores a model name
-    that's a full subset of a longer, suffix-decorated LM Arena entry as a near-perfect match,
-    instead of penalizing it for the extra suffix tokens. Version numbers are canonicalized
-    first (see canonicalize_version_numbers) so token_set_ratio's subset-leniency can't be
-    fooled by two unrelated version numbers that happen to share a lone digit (e.g. 3.5 vs 5.5)."""
-    provider, _, slug = full_model_name.lower().partition('/')
-    slug = canonicalize_version_numbers(slug.split(':', 1)[0])  # drop ':batch' etc., 3.5/4-6 -> 3p5/4p6
-
-    org_mask = score_df['organization'].apply(lambda org: orgs_match(normalize_org(provider), org))
-    candidates = score_df[org_mask] if org_mask.any() else score_df
-    names = candidates['model_name']
-
-    exact = candidates[names == slug]
-    if not exact.empty:
-        return exact['score'].max()
-
-    prefix_mask = names.apply(lambda name: name.startswith(slug)
-                              and (len(name) == len(slug) or not name[len(slug)].isdigit()))
-    if prefix_mask.any():
-        return candidates.loc[prefix_mask, 'score'].max()
-
-    best_score, best_ratio = None, 0
-    for name, score in zip(names, candidates['score']):
-        ratio = fuzz.token_set_ratio(slug, name)
-        if ratio > best_ratio:
-            best_score, best_ratio = score, ratio
-
-    return best_score if best_ratio >= threshold else None
-
-
-def lmarena_anchor_score(anchor_names, score_df):
-    """Averages the LM Arena scores of a list of reference models (see LMARENA_ANCHOR_* above)."""
-    scores = [s for s in (best_fuzzy_score(name, score_df) for name in anchor_names) if s is not None]
-    return sum(scores) / len(scores) if scores else None
-
-
-def compute_cost_estimate(prompt_price, completion_price):
-    """Weighted API price for a rough (coding/web-dev-flavored) run: 80% prompt, 20% completion."""
-    return 0.8 * prompt_price + 0.2 * completion_price
-
-
-def compute_scaled_cost_estimate(lm_arena_score, cost_estimate, baseline, half_life):
-    """Scales cost_estimate down for models that score above the 'good' baseline and up for
-    models that score below it. A model at the 'very good' anchor tier costs half as much (in
-    effective terms) as one at the baseline tier."""
-    if pd.isna(lm_arena_score) or baseline is None or not half_life:
-        return float('nan')
-
-    return cost_estimate * (2 ** (-(lm_arena_score - baseline) / half_life))
-
 
 # blocks UI method
 def on_load_ui():
@@ -162,19 +43,7 @@ def on_load_ui():
                              skip_experimental=True)
 
     score_df = load_lmarena_scores(LMARENA_SUBSET)
-    baseline = lmarena_anchor_score(LMARENA_ANCHOR_GOOD, score_df)
-    very_good = lmarena_anchor_score(LMARENA_ANCHOR_VERY_GOOD, score_df)
-    half_life = (very_good - baseline) if baseline is not None and very_good is not None else None
-
-    data_models['lm_arena_score'] = data_models['full_model_name'].apply(
-        lambda name: best_fuzzy_score(name, score_df))
-    data_models['cost_estimate'] = compute_cost_estimate(data_models['prompt_price'], data_models['completion_price'])
-    data_models['scaled_cost_estimate'] = data_models.apply(
-        lambda row: compute_scaled_cost_estimate(row['lm_arena_score'], row['cost_estimate'], baseline, half_life),
-        axis=1)
-    data_models = data_models[['full_model_name', 'lm_arena_score', 'scaled_cost_estimate', 'prompt_price',
-                               'completion_price', 'cost_estimate', 'context_length', 'max_completion_tokens',
-                               'provider']]
+    data_models = enrich_with_lmarena(data_models, score_df)
 
     # set precision of price/score values
     price_columns = data_models.filter(like='price').columns
@@ -345,8 +214,8 @@ with (gr.Blocks(fill_height=True, title='OpenRouter Model Choice') as llm_client
                                           type="pandas",
                                           show_search='search',
                                           interactive=False,
-                                          headers=['Full Model Name', 'LM Arena Score', 'Scaled Cost Estimate',
-                                                   'Prompt Price', 'Completion Price', 'Cost Estimate',
+                                          headers=['Full Model Name', 'LM Arena Score', 'Prompt Price',
+                                                   'Completion Price', 'Cost Estimate', 'Scaled Cost Estimate',
                                                    'Context Length', 'Max Completion Tokens', 'Provider'])
 
     # event handlers

--- a/demos/model_choice/chat_with_model_choice.py
+++ b/demos/model_choice/chat_with_model_choice.py
@@ -1,10 +1,14 @@
 import copy
+import glob
 import os
 import random
+import re
 import sys
 
 import gradio as gr
+import pandas as pd
 from dotenv import load_dotenv
+from thefuzz import fuzz
 
 sys.path.append('../../')
 
@@ -28,6 +32,124 @@ different_colors = ['#e6194b', '#3cb44b', '#ffe119', '#4363d8', '#f58231', '#911
                     '#fabebe', '#008080', '#e6beff', '#9a6324', '#fffac8', '#aaffc3', '#808000', '#ffd8b1', '#808080']
 providers = {}
 
+# --- LM Arena "bang for the buck" configuration --------------------------------------------
+# Which lmarena_download.py --subset CSV to blend in (run that script to (re)generate it).
+# One arena at a time by design; swap this to switch, rather than blending several incompatible scales.
+LMARENA_SUBSET = 'text_style_control'
+LMARENA_FUZZY_THRESHOLD = 75
+
+# Reference models that calibrate the value-estimate curve (see compute_value_cost below).
+# 'good' tier -> cost is left unadjusted (multiplier 1.0) at this quality level.
+# 'very_good' tier -> the point where the effective cost is halved.
+LMARENA_ANCHOR_GOOD = ['anthropic/claude-sonnet-4-5', 'anthropic/claude-sonnet-4-6']
+LMARENA_ANCHOR_VERY_GOOD = ['anthropic/claude-opus-4-6', 'anthropic/claude-opus-4-7']
+
+# OpenRouter provider slug -> LM Arena organization, for the handful of providers whose
+# product-brand slug doesn't share a substring with LM Arena's corporate-entity name
+# (e.g. OpenRouter's "qwen" vs LM Arena's "Alibaba"). Everything else is resolved by
+# normalizing both names and checking for substring containment (handles cases like
+# "z-ai"/"Z.ai", "mistralai"/"Mistral", "meta-llama"/"Meta", "moonshotai"/"Moonshot").
+LMARENA_ORG_ALIASES = {
+    'qwen': 'alibaba',
+}
+
+
+def normalize_org(name):
+    return re.sub(r'[^a-z0-9]', '', str(name).lower())
+
+
+def canonicalize_version_numbers(name):
+    """Joins short major/minor-style version numbers (e.g. '3.5', '4-6') into one indivisible
+    token ('3p5', '4p6'), on both sides of the comparison. Without this, thefuzz's tokenizer
+    splits '5.5' into two lone '5' tokens, which can make an unrelated model (e.g. gpt-5.5) look
+    like a perfect token-subset match for a short query (e.g. gpt-3.5) purely by digit coincidence.
+    Longer digit runs (date stamps like '20250929') are left alone -- they're a different token."""
+    return re.sub(r'\b(\d{1,2})[.\-](\d{1,2})\b', r'\1p\2', name)
+
+
+def orgs_match(provider_norm, organization):
+    org_norm = normalize_org(organization)
+    if LMARENA_ORG_ALIASES.get(provider_norm) == org_norm:
+        return True
+    return provider_norm in org_norm or org_norm in provider_norm
+
+
+def load_lmarena_scores(subset):
+    """Loads the most recently downloaded lmarena_<subset>_*.csv into an organization/model_name/score
+    DataFrame, ready for best_fuzzy_score() to filter by organization and match by model name."""
+    pattern = os.path.join(os.path.dirname(os.path.abspath(__file__)), f'lmarena_{subset}_*.csv')
+    matches = sorted(glob.glob(pattern))
+    if not matches:
+        print(f"Warning: no LM Arena CSV found for subset '{subset}'. "
+             f"Run `python3 lmarena_download.py --subset {subset}` first.")
+        return pd.DataFrame(columns=['organization', 'model_name', 'score'])
+
+    df_scores = pd.read_csv(matches[-1], sep=';')
+    df_scores = df_scores.dropna(subset=['model_name'])
+    df_scores['organization'] = df_scores['organization'].fillna('')
+    df_scores['model_name'] = df_scores['model_name'].str.lower().apply(canonicalize_version_numbers)
+    return df_scores[['organization', 'model_name', 'score']]
+
+
+def best_fuzzy_score(full_model_name, score_df, threshold=LMARENA_FUZZY_THRESHOLD):
+    """Finds the best-matching LM Arena score for an OpenRouter model id, bridging OpenRouter's
+    `provider/slug` ids and LM Arena's own model naming (which adds date stamps, effort suffixes
+    like '-high'/'-thinking-32k', etc.).
+
+    Matching happens in two stages: first narrow the candidate pool to the same organization
+    (see orgs_match above) to rule out cross-provider false matches, then match by model name
+    only -- exact, then prefix (so an exact-version match always wins over a shorter but wrong
+    adjacent version number, e.g. '4-6' vs '4-7'), then fuzzy token_set_ratio as a last resort.
+    token_set_ratio is used rather than token_sort_ratio/ratio because it scores a model name
+    that's a full subset of a longer, suffix-decorated LM Arena entry as a near-perfect match,
+    instead of penalizing it for the extra suffix tokens. Version numbers are canonicalized
+    first (see canonicalize_version_numbers) so token_set_ratio's subset-leniency can't be
+    fooled by two unrelated version numbers that happen to share a lone digit (e.g. 3.5 vs 5.5)."""
+    provider, _, slug = full_model_name.lower().partition('/')
+    slug = canonicalize_version_numbers(slug.split(':', 1)[0])  # drop ':batch' etc., 3.5/4-6 -> 3p5/4p6
+
+    org_mask = score_df['organization'].apply(lambda org: orgs_match(normalize_org(provider), org))
+    candidates = score_df[org_mask] if org_mask.any() else score_df
+    names = candidates['model_name']
+
+    exact = candidates[names == slug]
+    if not exact.empty:
+        return exact['score'].max()
+
+    prefix_mask = names.apply(lambda name: name.startswith(slug)
+                              and (len(name) == len(slug) or not name[len(slug)].isdigit()))
+    if prefix_mask.any():
+        return candidates.loc[prefix_mask, 'score'].max()
+
+    best_score, best_ratio = None, 0
+    for name, score in zip(names, candidates['score']):
+        ratio = fuzz.token_set_ratio(slug, name)
+        if ratio > best_ratio:
+            best_score, best_ratio = score, ratio
+
+    return best_score if best_ratio >= threshold else None
+
+
+def lmarena_anchor_score(anchor_names, score_df):
+    """Averages the LM Arena scores of a list of reference models (see LMARENA_ANCHOR_* above)."""
+    scores = [s for s in (best_fuzzy_score(name, score_df) for name in anchor_names) if s is not None]
+    return sum(scores) / len(scores) if scores else None
+
+
+def compute_cost_estimate(prompt_price, completion_price):
+    """Weighted API price for a rough (coding/web-dev-flavored) run: 80% prompt, 20% completion."""
+    return 0.8 * prompt_price + 0.2 * completion_price
+
+
+def compute_scaled_cost_estimate(lm_arena_score, cost_estimate, baseline, half_life):
+    """Scales cost_estimate down for models that score above the 'good' baseline and up for
+    models that score below it. A model at the 'very good' anchor tier costs half as much (in
+    effective terms) as one at the baseline tier."""
+    if pd.isna(lm_arena_score) or baseline is None or not half_life:
+        return float('nan')
+
+    return cost_estimate * (2 ** (-(lm_arena_score - baseline) / half_life))
+
 
 # blocks UI method
 def on_load_ui():
@@ -39,17 +161,38 @@ def on_load_ui():
                              skip_free=True,
                              skip_experimental=True)
 
-    # set precision of price values
+    score_df = load_lmarena_scores(LMARENA_SUBSET)
+    baseline = lmarena_anchor_score(LMARENA_ANCHOR_GOOD, score_df)
+    very_good = lmarena_anchor_score(LMARENA_ANCHOR_VERY_GOOD, score_df)
+    half_life = (very_good - baseline) if baseline is not None and very_good is not None else None
+
+    data_models['lm_arena_score'] = data_models['full_model_name'].apply(
+        lambda name: best_fuzzy_score(name, score_df))
+    data_models['cost_estimate'] = compute_cost_estimate(data_models['prompt_price'], data_models['completion_price'])
+    data_models['scaled_cost_estimate'] = data_models.apply(
+        lambda row: compute_scaled_cost_estimate(row['lm_arena_score'], row['cost_estimate'], baseline, half_life),
+        axis=1)
+    data_models = data_models[['full_model_name', 'lm_arena_score', 'scaled_cost_estimate', 'prompt_price',
+                               'completion_price', 'cost_estimate', 'context_length', 'max_completion_tokens',
+                               'provider']]
+
+    # set precision of price/score values
     price_columns = data_models.filter(like='price').columns
     format_dict = {col: "{:.3f}".format for col in price_columns}
     format_dict.update({col: "{:.0f}".format for col in ['max_completion_tokens']})
+    format_dict.update({'lm_arena_score': "{:.0f}".format, 'cost_estimate': "{:.3f}".format,
+                        'scaled_cost_estimate': "{:.3f}".format})
 
     style_models = (data_models.style
-                    .format(format_dict)
+                    .format(format_dict, na_rep='N/A')
                     .map(colorize_quantiles, df=data_models, col='completion_price', subset=['completion_price'])
                     .map(colorize_quantiles, df=data_models, col='prompt_price', subset=['prompt_price'])
+                    .map(colorize_quantiles, df=data_models, col='cost_estimate', subset=['cost_estimate'])
+                    .map(colorize_quantiles, df=data_models, col='scaled_cost_estimate',
+                        subset=['scaled_cost_estimate'])
                     .map(colorize_contexts, subset=['context_length'])
                     .map(colorize_providers, subset=['provider'])
+                    .map(colorize_scores, df=data_models, col='lm_arena_score', subset=['lm_arena_score'])
                     )
 
     return data_models, style_models
@@ -94,20 +237,14 @@ def colorize_providers(full_model_name):
 
 
 def colorize_scores(value, df, col):
-    """Colorizes scores based on quantiles."""
-    # Convert value to float if it's a string "N/A"
-    if isinstance(value, str) and value == "N/A":
-        numeric_value = float('-inf')
-    else:
-        numeric_value = float(value)  # Ensure it's a float for comparison
-
-    if numeric_value == -1 or numeric_value == float('-inf'):  # Models with no score or -inf from fuzzy matching
+    """Colorizes LM Arena scores based on quantiles; models with no matching score are left grey."""
+    if pd.isna(value):
         return 'color:grey;'
-    if numeric_value >= df[col].quantile(0.95):
+    if value >= df[col].quantile(0.9):
         return 'color:green;'
-    if numeric_value < df[col].quantile(0.35):
+    if value < df[col].quantile(0.35):
         return 'color:red;'
-    if numeric_value < df[col].quantile(0.65):
+    if value < df[col].quantile(0.65):
         return 'color:orange;'
     return ''
 
@@ -208,9 +345,9 @@ with (gr.Blocks(fill_height=True, title='OpenRouter Model Choice') as llm_client
                                           type="pandas",
                                           show_search='search',
                                           interactive=False,
-                                          headers=['Full Model Name', 'Prompt Price',
-                                                   'Completion Price', 'Context Length',
-                                                   'Max Completion Tokens', 'Provider'])
+                                          headers=['Full Model Name', 'LM Arena Score', 'Scaled Cost Estimate',
+                                                   'Prompt Price', 'Completion Price', 'Cost Estimate',
+                                                   'Context Length', 'Max Completion Tokens', 'Provider'])
 
     # event handlers
     tb_user.submit(append_user,

--- a/demos/model_choice/lmarena_download.py
+++ b/demos/model_choice/lmarena_download.py
@@ -33,6 +33,15 @@ def download_leaderboard(subset, category='overall'):
     return df_leaderboard[['model_name', 'organization', 'score', 'rank', 'leaderboard_publish_date']]
 
 
+def save_leaderboard_csv(df_leaderboard, subset, out_dir='.'):
+    """Saves a leaderboard DataFrame using the lmarena_<subset>_<date>.csv naming convention
+    that load_lmarena_scores() (in lmarena_scoring.py) looks for. Returns the path written."""
+    filename = f'lmarena_{subset}_{date.today().strftime("%y%m%d")}.csv'
+    out_path = f'{out_dir}/{filename}'
+    df_leaderboard.to_csv(out_path, sep=';', index=False)
+    return out_path
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Download an LMArena leaderboard snapshot from the official '
                                                   'Hugging Face dataset (lmarena-ai/leaderboard-dataset).')
@@ -46,7 +55,5 @@ if __name__ == '__main__':
     df_result = download_leaderboard(args.subset, args.category)
     print(f'Downloaded {len(df_result)} models for subset={args.subset!r}, category={args.category!r}.')
 
-    filename = f'lmarena_{args.subset}_{date.today().strftime("%y%m%d")}.csv'
-    out_path = f'{args.out_dir}/{filename}'
-    df_result.to_csv(out_path, sep=';', index=False)
+    out_path = save_leaderboard_csv(df_result, args.subset, args.out_dir)
     print(f'Saved to {out_path}')

--- a/demos/model_choice/lmarena_download.py
+++ b/demos/model_choice/lmarena_download.py
@@ -27,6 +27,10 @@ def download_leaderboard(subset, category='overall'):
 
     df_leaderboard = pd.read_parquet(url)
     df_leaderboard = df_leaderboard[df_leaderboard['category'] == category]
+    if df_leaderboard.empty:
+        raise ValueError(f"No rows found for category={category!r} in subset={subset!r} "
+                         f"-- check for a typo in --category.")
+
     df_leaderboard = df_leaderboard.rename(columns={score_column: 'score'})
     df_leaderboard['score'] = df_leaderboard['score'].round(2)
 

--- a/demos/model_choice/lmarena_download.py
+++ b/demos/model_choice/lmarena_download.py
@@ -1,0 +1,52 @@
+import argparse
+from datetime import date
+
+import pandas as pd
+
+DATASET_BASE_URL = 'https://huggingface.co/datasets/lmarena-ai/leaderboard-dataset/resolve/main'
+
+# subset -> name of the column holding the leaderboard score in that subset's parquet files.
+# (most arenas publish Bradley-Terry "rating"; the agent arena publishes an IPS "score" instead.)
+SUBSET_SCORE_COLUMNS = {
+    'text': 'rating',
+    'text_style_control': 'rating',
+    'webdev': 'rating',
+    'vision': 'rating',
+    'vision_style_control': 'rating',
+    'search': 'rating',
+    'search_style_control': 'rating',
+    'document': 'rating',
+    'document_style_control': 'rating',
+    'agent': 'score',
+}
+
+
+def download_leaderboard(subset, category='overall'):
+    score_column = SUBSET_SCORE_COLUMNS[subset]
+    url = f'{DATASET_BASE_URL}/{subset}/latest-00000-of-00001.parquet'
+
+    df_leaderboard = pd.read_parquet(url)
+    df_leaderboard = df_leaderboard[df_leaderboard['category'] == category]
+    df_leaderboard = df_leaderboard.rename(columns={score_column: 'score'})
+    df_leaderboard['score'] = df_leaderboard['score'].round(2)
+
+    return df_leaderboard[['model_name', 'organization', 'score', 'rank', 'leaderboard_publish_date']]
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Download an LMArena leaderboard snapshot from the official '
+                                                  'Hugging Face dataset (lmarena-ai/leaderboard-dataset).')
+    parser.add_argument('--subset', default='text_style_control', choices=sorted(SUBSET_SCORE_COLUMNS.keys()),
+                        help='Which arena leaderboard to download.')
+    parser.add_argument('--category', default='overall',
+                        help="Category within the subset to keep (default: 'overall').")
+    parser.add_argument('--out-dir', default='.', help='Folder to write the CSV into.')
+    args = parser.parse_args()
+
+    df_result = download_leaderboard(args.subset, args.category)
+    print(f'Downloaded {len(df_result)} models for subset={args.subset!r}, category={args.category!r}.')
+
+    filename = f'lmarena_{args.subset}_{date.today().strftime("%y%m%d")}.csv'
+    out_path = f'{args.out_dir}/{filename}'
+    df_result.to_csv(out_path, sep=';', index=False)
+    print(f'Saved to {out_path}')

--- a/demos/model_choice/lmarena_scoring.py
+++ b/demos/model_choice/lmarena_scoring.py
@@ -1,0 +1,151 @@
+import glob
+import os
+import re
+
+import pandas as pd
+from thefuzz import fuzz
+
+# Which lmarena_download.py --subset CSV to blend in by default (run that script to (re)generate it).
+# One arena at a time by design; swap this to switch, rather than blending several incompatible scales.
+LMARENA_SUBSET = 'text_style_control'
+LMARENA_FUZZY_THRESHOLD = 75
+
+# Reference models that calibrate the scaled-cost-estimate curve (see compute_scaled_cost_estimate below).
+# 'good' tier -> cost is left unadjusted (multiplier 1.0) at this quality level.
+# 'very_good' tier -> the point where the effective cost is halved.
+LMARENA_ANCHOR_GOOD = ['anthropic/claude-sonnet-4-5', 'anthropic/claude-sonnet-4-6']
+LMARENA_ANCHOR_VERY_GOOD = ['anthropic/claude-opus-4-6', 'anthropic/claude-opus-4-7']
+
+# OpenRouter provider slug -> LM Arena organization, for the handful of providers whose
+# product-brand slug doesn't share a substring with LM Arena's corporate-entity name
+# (e.g. OpenRouter's "qwen" vs LM Arena's "Alibaba"). Everything else is resolved by
+# normalizing both names and checking for substring containment (handles cases like
+# "z-ai"/"Z.ai", "mistralai"/"Mistral", "meta-llama"/"Meta", "moonshotai"/"Moonshot").
+LMARENA_ORG_ALIASES = {
+    'qwen': 'alibaba',
+}
+
+
+def normalize_org(name):
+    return re.sub(r'[^a-z0-9]', '', str(name).lower())
+
+
+def canonicalize_version_numbers(name):
+    """Joins short major/minor-style version numbers (e.g. '3.5', '4-6') into one indivisible
+    token ('3p5', '4p6'), on both sides of the comparison. Without this, thefuzz's tokenizer
+    splits '5.5' into two lone '5' tokens, which can make an unrelated model (e.g. gpt-5.5) look
+    like a perfect token-subset match for a short query (e.g. gpt-3.5) purely by digit coincidence.
+    Longer digit runs (date stamps like '20250929') are left alone -- they're a different token."""
+    return re.sub(r'\b(\d{1,2})[.\-](\d{1,2})\b', r'\1p\2', name)
+
+
+def orgs_match(provider_norm, organization):
+    org_norm = normalize_org(organization)
+    if LMARENA_ORG_ALIASES.get(provider_norm) == org_norm:
+        return True
+    return provider_norm in org_norm or org_norm in provider_norm
+
+
+def normalize_lmarena_df(df_scores):
+    """Cleans a raw LM Arena leaderboard DataFrame (as returned by lmarena_download.download_leaderboard,
+    or read straight from one of its CSVs) into the organization/model_name/score shape that
+    best_fuzzy_score() expects."""
+    df_scores = df_scores.dropna(subset=['model_name']).copy()
+    df_scores['organization'] = df_scores['organization'].fillna('')
+    df_scores['model_name'] = df_scores['model_name'].str.lower().apply(canonicalize_version_numbers)
+    return df_scores[['organization', 'model_name', 'score']]
+
+
+def load_lmarena_scores(subset):
+    """Loads the most recently downloaded lmarena_<subset>_*.csv into an organization/model_name/score
+    DataFrame, ready for best_fuzzy_score() to filter by organization and match by model name."""
+    pattern = os.path.join(os.path.dirname(os.path.abspath(__file__)), f'lmarena_{subset}_*.csv')
+    matches = sorted(glob.glob(pattern))
+    if not matches:
+        print(f"Warning: no LM Arena CSV found for subset '{subset}'. "
+             f"Run `python3 lmarena_download.py --subset {subset}` first.")
+        return pd.DataFrame(columns=['organization', 'model_name', 'score'])
+
+    return normalize_lmarena_df(pd.read_csv(matches[-1], sep=';'))
+
+
+def best_fuzzy_score(full_model_name, score_df, threshold=LMARENA_FUZZY_THRESHOLD):
+    """Finds the best-matching LM Arena score for an OpenRouter model id, bridging OpenRouter's
+    `provider/slug` ids and LM Arena's own model naming (which adds date stamps, effort suffixes
+    like '-high'/'-thinking-32k', etc.).
+
+    Matching happens in two stages: first narrow the candidate pool to the same organization
+    (see orgs_match above) to rule out cross-provider false matches, then match by model name
+    only -- exact, then prefix (so an exact-version match always wins over a shorter but wrong
+    adjacent version number, e.g. '4-6' vs '4-7'), then fuzzy token_set_ratio as a last resort.
+    token_set_ratio is used rather than token_sort_ratio/ratio because it scores a model name
+    that's a full subset of a longer, suffix-decorated LM Arena entry as a near-perfect match,
+    instead of penalizing it for the extra suffix tokens. Version numbers are canonicalized
+    first (see canonicalize_version_numbers) so token_set_ratio's subset-leniency can't be
+    fooled by two unrelated version numbers that happen to share a lone digit (e.g. 3.5 vs 5.5)."""
+    provider, _, slug = full_model_name.lower().partition('/')
+    slug = canonicalize_version_numbers(slug.split(':', 1)[0])  # drop ':batch' etc., 3.5/4-6 -> 3p5/4p6
+
+    org_mask = score_df['organization'].apply(lambda org: orgs_match(normalize_org(provider), org))
+    candidates = score_df[org_mask] if org_mask.any() else score_df
+    names = candidates['model_name']
+
+    exact = candidates[names == slug]
+    if not exact.empty:
+        return exact['score'].max()
+
+    prefix_mask = names.apply(lambda name: name.startswith(slug)
+                              and (len(name) == len(slug) or not name[len(slug)].isdigit()))
+    if prefix_mask.any():
+        return candidates.loc[prefix_mask, 'score'].max()
+
+    best_score, best_ratio = None, 0
+    for name, score in zip(names, candidates['score']):
+        ratio = fuzz.token_set_ratio(slug, name)
+        if ratio > best_ratio:
+            best_score, best_ratio = score, ratio
+
+    return best_score if best_ratio >= threshold else None
+
+
+def lmarena_anchor_score(anchor_names, score_df):
+    """Averages the LM Arena scores of a list of reference models (see LMARENA_ANCHOR_* above)."""
+    scores = [s for s in (best_fuzzy_score(name, score_df) for name in anchor_names) if s is not None]
+    return sum(scores) / len(scores) if scores else None
+
+
+def compute_cost_estimate(prompt_price, completion_price):
+    """Weighted API price for a rough (coding/web-dev-flavored) run: 80% prompt, 20% completion."""
+    return round(0.8 * prompt_price + 0.2 * completion_price, 2)
+
+
+def compute_scaled_cost_estimate(lm_arena_score, cost_estimate, baseline, half_life):
+    """Scales cost_estimate down for models that score above the 'good' baseline and up for
+    models that score below it. A model at the 'very good' anchor tier costs half as much (in
+    effective terms) as one at the baseline tier."""
+    if pd.isna(lm_arena_score) or baseline is None or not half_life:
+        return float('nan')
+
+    return round(cost_estimate * (2 ** (-(lm_arena_score - baseline) / half_life)), 2)
+
+
+def enrich_with_lmarena(data_models, score_df):
+    """Adds lm_arena_score, cost_estimate and scaled_cost_estimate columns to an OpenRouter
+    pricing DataFrame (as returned by or_model_filtering.get_models), and reorders the columns
+    for display. score_df should come from load_lmarena_scores() or normalize_lmarena_df()."""
+    baseline = lmarena_anchor_score(LMARENA_ANCHOR_GOOD, score_df)
+    very_good = lmarena_anchor_score(LMARENA_ANCHOR_VERY_GOOD, score_df)
+    half_life = (very_good - baseline) if baseline is not None and very_good is not None else None
+
+    data_models = data_models.copy()
+    data_models['lm_arena_score'] = data_models['full_model_name'].apply(
+        lambda name: best_fuzzy_score(name, score_df))
+    data_models['cost_estimate'] = compute_cost_estimate(data_models['prompt_price'], data_models['completion_price'])
+    data_models['scaled_cost_estimate'] = data_models.apply(
+        lambda row: compute_scaled_cost_estimate(row['lm_arena_score'], row['cost_estimate'], baseline, half_life),
+        axis=1)
+
+    data_models = data_models[['full_model_name', 'lm_arena_score', 'prompt_price', 'completion_price',
+                               'cost_estimate', 'scaled_cost_estimate', 'context_length', 'max_completion_tokens',
+                               'provider']]
+    return data_models.round(2)  # belt-and-suspenders: no long floating-point tails in any numeric column

--- a/demos/model_choice/lmarena_scoring.py
+++ b/demos/model_choice/lmarena_scoring.py
@@ -41,6 +41,8 @@ def canonicalize_version_numbers(name):
 
 def orgs_match(provider_norm, organization):
     org_norm = normalize_org(organization)
+    if not provider_norm or not org_norm:
+        return False
     if LMARENA_ORG_ALIASES.get(provider_norm) == org_norm:
         return True
     return provider_norm in org_norm or org_norm in provider_norm
@@ -116,17 +118,17 @@ def lmarena_anchor_score(anchor_names, score_df):
 
 def compute_cost_estimate(prompt_price, completion_price):
     """Weighted API price for a rough (coding/web-dev-flavored) run: 80% prompt, 20% completion."""
-    return round(0.8 * prompt_price + 0.2 * completion_price, 2)
+    return round(0.8 * prompt_price + 0.2 * completion_price, 3)
 
 
 def compute_scaled_cost_estimate(lm_arena_score, cost_estimate, baseline, half_life):
     """Scales cost_estimate down for models that score above the 'good' baseline and up for
     models that score below it. A model at the 'very good' anchor tier costs half as much (in
     effective terms) as one at the baseline tier."""
-    if pd.isna(lm_arena_score) or baseline is None or not half_life:
+    if pd.isna(lm_arena_score) or baseline is None or half_life is None or half_life <= 0:
         return float('nan')
 
-    return round(cost_estimate * (2 ** (-(lm_arena_score - baseline) / half_life)), 2)
+    return round(cost_estimate * (2 ** (-(lm_arena_score - baseline) / half_life)), 3)
 
 
 def enrich_with_lmarena(data_models, score_df):
@@ -148,4 +150,4 @@ def enrich_with_lmarena(data_models, score_df):
     data_models = data_models[['full_model_name', 'lm_arena_score', 'prompt_price', 'completion_price',
                                'cost_estimate', 'scaled_cost_estimate', 'context_length', 'max_completion_tokens',
                                'provider']]
-    return data_models.round(2)  # belt-and-suspenders: no long floating-point tails in any numeric column
+    return data_models.round(3)  # belt-and-suspenders: no long floating-point tails in any numeric column

--- a/demos/model_choice/requirements.txt
+++ b/demos/model_choice/requirements.txt
@@ -1,7 +1,7 @@
-gradio~=6.17.3
-openai~=2.7.1
+gradio~=6.19.0
+openai~=2.53.0
 python-dotenv~=1.2.2
-requests~=2.33.0
+requests~=2.34.2
 pandas~=2.3.3
 thefuzz~=0.22.1
 pyarrow~=25.0.0

--- a/demos/model_choice/requirements.txt
+++ b/demos/model_choice/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv~=1.2.2
 requests~=2.33.0
 pandas~=2.3.3
 thefuzz~=0.22.1
+pyarrow~=25.0.0

--- a/demos/rag/launch_query_test.py
+++ b/demos/rag/launch_query_test.py
@@ -1,4 +1,7 @@
 import json
+import sys
+
+sys.path.append('../../')
 
 from components.vectorstore.chroma_document_store import ChromaDocumentStore
 

--- a/demos/rag/launch_upload_ui.py
+++ b/demos/rag/launch_upload_ui.py
@@ -1,5 +1,9 @@
+import sys
+
 import gradio as gr
 from tqdm import tqdm
+
+sys.path.append('../../')
 
 from components.text_utils.md_chunking import iterative_chunking
 from components.text_utils.md_conversion import document_to_markdown
@@ -22,27 +26,17 @@ def on_file_uploaded(file_list, progress=gr.Progress(track_tqdm=True)):
                                    meta_infos=meta_info,
                                    tqdm_func=tqdm)
 
-    return [None, wrap_document_list()]
+    return None, refresh_document_choices()
 
 
-def on_remove_rag(file_list, select_data):
-    if select_data is not None:
-        document_name = file_list['Name'][select_data[0]]
-        cdb_store.remove_document(document_name)
-    names = cdb_store.list_documents()
-    return names, None
+def on_remove_rag(selected_name):
+    if selected_name is not None:
+        cdb_store.remove_document(selected_name)
+    return refresh_document_choices()
 
 
-def wrap_document_list():
-    doc_list = cdb_store.list_documents()
-    wrapped_list = []
-    for doc_name in doc_list:
-        wrapped_list.append([doc_name])
-    return wrapped_list
-
-
-def on_row_selected(select_data: gr.SelectData):
-    return select_data.index
+def refresh_document_choices():
+    return gr.Radio(choices=cdb_store.list_documents(), value=None)
 
 
 rag_explainer = (
@@ -57,8 +51,6 @@ custom_css = """
 """
 
 with gr.Blocks(fill_height=True, title='RAG Upload Demo') as cdb_demo:
-    st_selected_index = gr.State()
-
     # UI elements
     lbl_rag_explainer = gr.Markdown(rag_explainer)
 
@@ -67,10 +59,7 @@ with gr.Blocks(fill_height=True, title='RAG Upload Demo') as cdb_demo:
                               file_count='multiple')
 
     with gr.Row(scale=1):
-        df_rag_files = gr.Dataframe(label='Collections',
-                                    headers=['Name'],
-                                    column_count=1,
-                                    interactive=False)
+        rd_rag_files = gr.Radio(label='Collections')
 
         btn_remove_rag_file = gr.Button(value='',
                                         scale=0,
@@ -79,9 +68,8 @@ with gr.Blocks(fill_height=True, title='RAG Upload Demo') as cdb_demo:
                                         elem_classes='danger')
 
     # event handlers
-    file_rag_upload.upload(on_file_uploaded, [file_rag_upload], [file_rag_upload, df_rag_files])
-    df_rag_files.select(on_row_selected, None, [st_selected_index])
-    btn_remove_rag_file.click(on_remove_rag, [df_rag_files, st_selected_index], [df_rag_files, st_selected_index])
-    cdb_demo.load(wrap_document_list, [], [df_rag_files])
+    file_rag_upload.upload(on_file_uploaded, [file_rag_upload], [file_rag_upload, rd_rag_files])
+    btn_remove_rag_file.click(on_remove_rag, [rd_rag_files], [rd_rag_files])
+    cdb_demo.load(refresh_document_choices, [], [rd_rag_files])
 
 cdb_demo.queue().launch(server_name='0.0.0.0', server_port=7021, css=custom_css)

--- a/demos/rag/requirements.txt
+++ b/demos/rag/requirements.txt
@@ -1,4 +1,4 @@
-gradio~=6.17.3
-chromadb~=1.3.5
-markitdown[pdf, docx, pptx, xlsx, xls]~=0.1.4
-tqdm~=4.67.2
+gradio~=6.19.0
+chromadb~=1.5.9
+markitdown[pdf, docx, pptx, xlsx, xls]~=0.1.6
+tqdm~=4.68.2

--- a/demos/slack_bot/requirements.txt
+++ b/demos/slack_bot/requirements.txt
@@ -1,6 +1,6 @@
 python-dotenv~=1.2.2
-openai~=2.7.1
-slack_bolt~=1.26.0
-markdownify~=1.2.2
-selenium~=4.38.0
-webdriver-manager~=4.0.2
+openai~=2.53.0
+slack_bolt~=1.29.0
+markdownify~=1.2.3
+selenium~=4.45.0
+webdriver-manager~=4.1.2

--- a/demos/tool_calling/chat_with_tool_calling.py
+++ b/demos/tool_calling/chat_with_tool_calling.py
@@ -1,8 +1,11 @@
 import json
 import os
+import sys
 
 import gradio as gr
 from dotenv import load_dotenv
+
+sys.path.append('../../')
 
 from components.open_router.open_router_client import OpenRouterClient
 from demos.tool_calling.descriptors_fileio import tools_fileio_descriptor

--- a/demos/tool_calling/requirements.txt
+++ b/demos/tool_calling/requirements.txt
@@ -1,9 +1,9 @@
-gradio~=6.17.3
+gradio~=6.19.0
 python-dotenv~=1.2.2
-openai~=2.7.1
-chromadb~=1.3.5
-markdownify~=1.2.2
-selenium~=4.38.0
-webdriver-manager~=4.0.2
-requests~=2.33.0
-tiktoken~=0.12.0
+openai~=2.53.0
+chromadb~=1.5.9
+markdownify~=1.2.3
+selenium~=4.45.0
+webdriver-manager~=4.1.2
+requests~=2.34.2
+tiktoken~=0.13.0

--- a/demos/voice_notes/requirements.txt
+++ b/demos/voice_notes/requirements.txt
@@ -1,8 +1,8 @@
 gradio~=6.17.3
-openai~=2.7.1
+openai~=2.53.0
 python-dotenv~=1.2.2
-scipy~=1.16.3
+scipy~=1.17.1
 transformers~=4.56.0
-accelerate~=1.4.0
-torch>=2.8.0
-torchaudio>=2.2.2
+accelerate~=1.14.0
+torch>=2.12.0
+torchaudio>=2.11.0


### PR DESCRIPTION
This pull request adds LM Arena leaderboard integration to the model selection demo, blending OpenRouter pricing with quality scores and cost estimates. It introduces scripts for downloading and matching LM Arena scores to OpenRouter models, computes new cost columns, and updates the UI and documentation to display this richer information.

**LM Arena Integration and Scoring:**

* Added `lmarena_download.py` to fetch and save LM Arena leaderboard snapshots from Hugging Face, supporting multiple subsets and categories.
* Introduced `lmarena_scoring.py` for matching OpenRouter model IDs to LM Arena entries using fuzzy matching, and for computing new columns: `lm_arena_score`, `cost_estimate`, and `scaled_cost_estimate`.
* Updated `chat_with_model_choice.py` to load LM Arena scores, enrich the model DataFrame with scores and cost estimates, and colorize/sort the new columns in the UI. [[1]](diffhunk://#diff-4cd7ed308c127c7efc6a6eb5d34b0627272e76e11b858383401cbf858cfb1747R7-R11) [[2]](diffhunk://#diff-4cd7ed308c127c7efc6a6eb5d34b0627272e76e11b858383401cbf858cfb1747L42-R64) [[3]](diffhunk://#diff-4cd7ed308c127c7efc6a6eb5d34b0627272e76e11b858383401cbf858cfb1747L97-R116) [[4]](diffhunk://#diff-4cd7ed308c127c7efc6a6eb5d34b0627272e76e11b858383401cbf858cfb1747L211-R219)

**Reporting and Data Processing:**

* Added `build_model_report.py` to generate a combined CSV report with OpenRouter pricing, LM Arena scores, and cost estimates for spreadsheet analysis.
* Improved price rounding in `or_model_filtering.py` and ensured all numeric columns are rounded to avoid floating-point tails. [[1]](diffhunk://#diff-9f089cd6752457a2c582d651fad9af41c97a64f5acac1d056cc68081b5ea2ae9L62-R63) [[2]](diffhunk://#diff-9f089cd6752457a2c582d651fad9af41c97a64f5acac1d056cc68081b5ea2ae9R93)

**Documentation and Dependencies:**

* Expanded the README to explain the new scoring, cost columns, and workflow for refreshing LM Arena data.
* Added `pyarrow` to requirements for reading Parquet leaderboard files.