### PR TITLE
Model report: sort by score, skip batch models, colorized HTML output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,5 +177,6 @@ logs/
 
 # data
 *.csv
+*.html
 
 sonar-project.properties

--- a/components/open_router/or_model_filtering.py
+++ b/components/open_router/or_model_filtering.py
@@ -14,7 +14,8 @@ def get_models(tools_only=False,
                max_prompt_price=0,  # good value: 10
                skip_free=True,
                skip_experimental=True,
-               exacto_only=False):
+               exacto_only=False,
+               skip_batch=False):
     models_url = 'https://openrouter.ai/api/v1/models'
     if tools_only:
         models_url += '?supported_parameters=tools'
@@ -28,6 +29,9 @@ def get_models(tools_only=False,
     if skip_experimental:
         filtered_data = [m for m in filtered_data if
                          not any(term in m['id'] for term in ['beta', '-exp', ':free'])]  # remove experimental / beta
+
+    if skip_batch:
+        filtered_data = [m for m in filtered_data if ':batch' not in m['id']]  # skip batch models
 
     # context
     if min_context > 0:

--- a/demos/model_choice/build_model_report.py
+++ b/demos/model_choice/build_model_report.py
@@ -24,7 +24,8 @@ if __name__ == '__main__':
                              max_completion_price=0,
                              max_prompt_price=0,
                              skip_free=True,
-                             skip_experimental=False)
+                             skip_experimental=False,
+                             skip_batch=True)
 
     print(f'Fetching LM Arena {args.subset!r} leaderboard...')
     df_leaderboard = download_leaderboard(args.subset)
@@ -32,6 +33,7 @@ if __name__ == '__main__':
     print(f'Saved LM Arena snapshot to {lmarena_path}')
 
     data_models = enrich_with_lmarena(data_models, normalize_lmarena_df(df_leaderboard))
+    data_models = data_models.sort_values(by='lm_arena_score', ascending=False)
     data_models.to_csv(args.out, index=False)
 
     matched = data_models['lm_arena_score'].notna().sum()

--- a/demos/model_choice/build_model_report.py
+++ b/demos/model_choice/build_model_report.py
@@ -4,6 +4,7 @@ import sys
 sys.path.append('../../')
 
 from components.open_router.or_model_filtering import get_models
+from html_report import write_html_report
 from lmarena_download import download_leaderboard, save_leaderboard_csv, SUBSET_SCORE_COLUMNS
 from lmarena_scoring import LMARENA_SUBSET, normalize_lmarena_df, enrich_with_lmarena
 
@@ -15,6 +16,8 @@ if __name__ == '__main__':
     parser.add_argument('--subset', default=LMARENA_SUBSET, choices=sorted(SUBSET_SCORE_COLUMNS.keys()),
                         help='Which LM Arena leaderboard to blend in.')
     parser.add_argument('--out', default='or_lmarena_report.csv', help='Filename for the combined report.')
+    parser.add_argument('--html-out', default=None,
+                        help='Optional filename for a colorized HTML version of the report.')
     args = parser.parse_args()
 
     print('Fetching OpenRouter pricing...')
@@ -38,3 +41,7 @@ if __name__ == '__main__':
 
     matched = data_models['lm_arena_score'].notna().sum()
     print(f'Matched {matched}/{len(data_models)} models. Saved combined report to {args.out}')
+
+    if args.html_out:
+        write_html_report(data_models, args.html_out)
+        print(f'Saved colorized HTML report to {args.html_out}')

--- a/demos/model_choice/html_report.py
+++ b/demos/model_choice/html_report.py
@@ -1,0 +1,72 @@
+import pandas as pd
+
+# Color anchors for the report's gradient columns (red -> yellow -> green).
+SCORE_RED = 1410
+SCORE_YELLOW = 1440
+SCORE_GREEN = 1470
+
+# Price column anchors (green -> yellow -> red): green = cheap/good, red = expensive/bad.
+PROMPT_PRICE_GREEN, PROMPT_PRICE_YELLOW, PROMPT_PRICE_RED = 1, 1.5, 5
+COMPLETION_PRICE_GREEN, COMPLETION_PRICE_YELLOW, COMPLETION_PRICE_RED = 2.5, 7.5, 20
+COST_ESTIMATE_GREEN, COST_ESTIMATE_YELLOW, COST_ESTIMATE_RED = 1, 2, 5  # shared by cost_estimate and scaled_cost_estimate
+
+RED = (240, 100, 100)
+YELLOW = (255, 235, 132)
+GREEN = (99, 190, 123)
+
+# column -> (low, mid, high, low_color, mid_color, high_color) passed straight to _gradient_color
+COLUMN_GRADIENTS = {
+    'lm_arena_score': (SCORE_RED, SCORE_YELLOW, SCORE_GREEN, RED, YELLOW, GREEN),
+    'prompt_price': (PROMPT_PRICE_GREEN, PROMPT_PRICE_YELLOW, PROMPT_PRICE_RED, GREEN, YELLOW, RED),
+    'completion_price': (COMPLETION_PRICE_GREEN, COMPLETION_PRICE_YELLOW, COMPLETION_PRICE_RED, GREEN, YELLOW, RED),
+    'cost_estimate': (COST_ESTIMATE_GREEN, COST_ESTIMATE_YELLOW, COST_ESTIMATE_RED, GREEN, YELLOW, RED),
+    'scaled_cost_estimate': (COST_ESTIMATE_GREEN, COST_ESTIMATE_YELLOW, COST_ESTIMATE_RED, GREEN, YELLOW, RED),
+}
+
+TABLE_STYLES = [
+    {'selector': 'table, th, td', 'props': [('font-family', 'Segoe UI, Helvetica, Arial, sans-serif')]},
+    {'selector': 'th, td', 'props': [('padding', '6px 14px')]},
+]
+
+
+def _lerp_color(color_a, color_b, t):
+    t = max(0.0, min(1.0, t))
+    return tuple(round(a + (b - a) * t) for a, b in zip(color_a, color_b))
+
+
+def _to_hex(rgb):
+    return '#{:02x}{:02x}{:02x}'.format(*rgb)
+
+
+def _gradient_color(value, low, mid, high, low_color, mid_color, high_color):
+    """Interpolates a background-color CSS declaration for value across a
+    low -> mid -> high three-point color scale, clamped at both ends."""
+    if pd.isna(value):
+        return ''
+    if value <= low:
+        rgb = low_color
+    elif value >= high:
+        rgb = high_color
+    elif value <= mid:
+        rgb = _lerp_color(low_color, mid_color, (value - low) / (mid - low))
+    else:
+        rgb = _lerp_color(mid_color, high_color, (value - mid) / (high - mid))
+    return f'background-color: {_to_hex(rgb)}'
+
+
+def render_html_report(data_models):
+    """Returns an HTML string rendering of data_models with color-scaled lm_arena_score and
+    price columns, per the low -> mid -> high anchors defined in COLUMN_GRADIENTS."""
+    styler = data_models.style.hide(axis='index')
+    styler = styler.set_table_styles(TABLE_STYLES)
+    styler = styler.format('{:.2f}', subset=list(COLUMN_GRADIENTS.keys()))
+    for column, anchors in COLUMN_GRADIENTS.items():
+        if column in data_models.columns:
+            styler = styler.map(lambda v, anchors=anchors: _gradient_color(v, *anchors), subset=[column])
+    return styler.to_html()
+
+
+def write_html_report(data_models, out_path):
+    with open(out_path, 'wt') as fp:
+        fp.write(render_html_report(data_models))
+    return out_path

--- a/demos/model_choice/html_report.py
+++ b/demos/model_choice/html_report.py
@@ -28,6 +28,17 @@ TABLE_STYLES = [
     {'selector': 'th, td', 'props': [('padding', '6px 14px')]},
 ]
 
+# column -> decimal places to display
+NUMBER_FORMATS = {
+    'lm_arena_score': '{:.1f}',
+    'prompt_price': '{:.2f}',
+    'completion_price': '{:.2f}',
+    'cost_estimate': '{:.2f}',
+    'scaled_cost_estimate': '{:.2f}',
+    'context_length': '{:.0f}',
+    'max_completion_tokens': '{:.0f}',
+}
+
 
 def _lerp_color(color_a, color_b, t):
     t = max(0.0, min(1.0, t))
@@ -59,7 +70,8 @@ def render_html_report(data_models):
     price columns, per the low -> mid -> high anchors defined in COLUMN_GRADIENTS."""
     styler = data_models.style.hide(axis='index')
     styler = styler.set_table_styles(TABLE_STYLES)
-    styler = styler.format('{:.2f}', subset=list(COLUMN_GRADIENTS.keys()))
+    styler = styler.format({col: fmt for col, fmt in NUMBER_FORMATS.items() if col in data_models.columns},
+                           na_rep='')
     for column, anchors in COLUMN_GRADIENTS.items():
         if column in data_models.columns:
             styler = styler.map(lambda v, anchors=anchors: _gradient_color(v, *anchors), subset=[column])


### PR DESCRIPTION
## Summary
- `build_model_report.py` now sorts the combined report by `lm_arena_score` (highest first) and skips OpenRouter `:batch` model variants (via the existing `skip_batch` option in `or_model_filtering.get_models()`).
- Adds a `--html-out` flag that renders the report as a colorized HTML table alongside the CSV: a red/yellow/green gradient on `lm_arena_score` and the price/cost columns (cheap=green, expensive=red), sans-serif font, cell padding, and per-column decimal precision (score: 1 decimal, price/cost: 2 decimals, token counts: 0 decimals).
- `.gitignore` now excludes generated `*.html` report output, matching the existing `*.csv` rule.

## Test plan
- [x] Verified sorting and `:batch` filtering logic against `or_model_filtering.get_models()`.
- [x] Rendered `html_report.py` output against sample data to confirm gradient colors, font/padding CSS, and per-column decimal formatting (including NaN handling for missing `max_completion_tokens`).
- [x] Syntax-checked all changed files (`py_compile`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)